### PR TITLE
Turn off v2.0 for now

### DIFF
--- a/crossversion/xversion.py
+++ b/crossversion/xversion.py
@@ -15,7 +15,9 @@ import subprocess
 import shutil
 
 # put this in one place
-supported_versions = ["master", "v3.1", "v3.0", "v2.2", "v2.1", "v2.0"]
+# TURN OFF v2.0 WHILE GDS/HASH IS FORCED AS IT DOESN'T SUPPORT
+# NON-DSTORE OPS
+supported_versions = ["master", "v3.1", "v3.0", "v2.2", "v2.1"]
 
 pmix_git_url      = "https://github.com/pmix/pmix.git"
 pmix_release_url  = "https://github.com/pmix/pmix/releases/download/"


### PR DESCRIPTION
It doesn't support non-dstore ops and thus generates a false failure

Signed-off-by: Ralph Castain <rhc@pmix.org>