### PR TITLE
Update the CI tests to reflect change to proxy

### DIFF
--- a/prrte/cycle/run.sh
+++ b/prrte/cycle/run.sh
@@ -13,7 +13,7 @@ _shutdown()
     # ---------------------------------------
     # Cleanup DVM
     # ---------------------------------------
-    prun --terminate
+    pterm
 
     exit $FINAL_RTN
 }

--- a/prrte/hello_world/run.sh
+++ b/prrte/hello_world/run.sh
@@ -12,7 +12,7 @@ _shutdown()
     # ---------------------------------------
     # Cleanup DVM
     # ---------------------------------------
-    prun --terminate
+    pterm
 
     exit $FINAL_RTN
 }

--- a/prrte/prun-wrapper/run.sh
+++ b/prrte/prun-wrapper/run.sh
@@ -23,14 +23,9 @@ if [ "x" != "x$CI_HOSTFILE" ] ; then
 fi
 
 # ---------------------------------------
-# MCA parameter indicating that we are testing the proxy launch functionality
-# ---------------------------------------
-export PRRTE_MCA_schizo_base_test_proxy_launch=1
-
-# ---------------------------------------
 # Run the test - Hostname with --hostfile
 # ---------------------------------------
-prun --map-by ppr:5:node ${_HOSTFILE_ARG} hostname 2>&1 | tee output-hn.txt
+prte --map-by ppr:5:node ${_HOSTFILE_ARG} hostname 2>&1 | tee output-hn.txt
 
 # ---------------------------------------
 # Verify the results
@@ -54,9 +49,9 @@ fi
 # ---------------------------------------
 # Run the test - Hostname with --hostfile and full path
 # ---------------------------------------
-ABS_PATH=`which prun`
+ABS_PATH=`which prte`
 ABS_PATH=`dirname $ABS_PATH`
-$ABS_PATH/prun --map-by ppr:5:node ${_HOSTFILE_ARG} hostname 2>&1 | tee output-hn.txt
+$ABS_PATH/prte --map-by ppr:5:node ${_HOSTFILE_ARG} hostname 2>&1 | tee output-hn.txt
 
 # ---------------------------------------
 # Verify the results
@@ -81,7 +76,7 @@ fi
 # ---------------------------------------
 # Run the test - Hostname with --host
 # ---------------------------------------
-prun --map-by ppr:5:node ${_DASH_HOST_ARG} hostname 2>&1 | tee output-hn.txt
+prte --map-by ppr:5:node ${_DASH_HOST_ARG} hostname 2>&1 | tee output-hn.txt
 
 # ---------------------------------------
 # Verify the results
@@ -106,7 +101,7 @@ fi
 # ---------------------------------------
 # Run the test - Hello World (PMIx) with --hostfile
 # ---------------------------------------
-prun --map-by ppr:5:node ${_HOSTFILE_ARG} ../hello_world/hello 2>&1 | tee output.txt
+prte --map-by ppr:5:node ${_HOSTFILE_ARG} ../hello_world/hello 2>&1 | tee output.txt
 
 # ---------------------------------------
 # Verify the results
@@ -126,7 +121,7 @@ fi
 # ---------------------------------------
 # Run the test - Hello World (PMIx) with --hostfile
 # ---------------------------------------
-prun --map-by ppr:5:node ${_DASH_HOST_ARG} ../hello_world/hello 2>&1 | tee output.txt
+prte --map-by ppr:5:node ${_DASH_HOST_ARG} ../hello_world/hello 2>&1 | tee output.txt
 
 # ---------------------------------------
 # Verify the results


### PR DESCRIPTION
Use "prte" directly instead of "prun" with the proxy MCA param set. Use
pterm instead of "prun --terminate"

Signed-off-by: Ralph Castain <rhc@pmix.org>