### PR TITLE
Revert debug extensions

### DIFF
--- a/ci-builds/pmix/04-build-v4-with-prrte.sh
+++ b/ci-builds/pmix/04-build-v4-with-prrte.sh
@@ -88,7 +88,7 @@ export AUTOMAKE_JOBS=20
 # Configure
 #--------------------------------
 ./configure --prefix=${_BUILD_DIR}/install-prrte \
-            --enable-debug \
+            --disable-debug \
             --with-pmix=${_BUILD_DIR}/install-pmix \
             --with-libevent=${LIBEVENT_INSTALL_PATH} \
             --with-hwloc=${HWLOC1_INSTALL_PATH}

--- a/prrte/prun-wrapper/run.sh
+++ b/prrte/prun-wrapper/run.sh
@@ -25,7 +25,7 @@ fi
 # ---------------------------------------
 # Run the test - Hostname with --hostfile
 # ---------------------------------------
-prterun --map-by ppr:5:node ${_HOSTFILE_ARG} --prtemca iof_base_verbose 5 --prtemca pmix_server_verbose 5 hostname 2>&1 | tee output-hn.txt
+prterun --map-by ppr:5:node ${_HOSTFILE_ARG} hostname 2>&1 | tee output-hn.txt
 
 # ---------------------------------------
 # Verify the results


### PR DESCRIPTION
Revert "Enable PRRTE debug on PMIx CI"
This reverts commit d01b213b6f77622a1cd87f63fb2152a6e861657f.

Revert "Add some debug to the prterun test"
This reverts commit ec7a3c87caf6e9c7497d72993c21b86e53b92627.

Signed-off-by: Ralph Castain <rhc@pmix.org>