### PR TITLE
Temporarily disable indirect and attach cases due to breaking CI

### DIFF
--- a/prrte/debug/run.py
+++ b/prrte/debug/run.py
@@ -33,9 +33,9 @@ ATTACH_WAITTIME = 10.0
 # A multinode testcase includes MULTINODE_TEST in it's testcase flags settings
 tests = [ ["direct", SYS_DAEMON_NEEDED, "./direct"],
           ["direct-cospawn", SYS_DAEMON_NEEDED, "./direct", "-c"],
-          ["attach", ATTACH_TARGET_NEEDED, "./attach", "$attach-namespace"],
-          ["indirect-prterun", 0, "./indirect", "prterun", "-n", "2",
-                  "./hello", "10"]
+#         ["attach", ATTACH_TARGET_NEEDED, "./attach", "$attach-namespace"],
+#         ["indirect-prterun", 0, "./indirect", "prterun", "-n", "2",
+#                 "./hello", "10"]
 # These testcases are not working at this point, so comment them out for now
 #          ["indirect", SYS_DAEMON_NEEDED, "./indirect", "prun", "-n", "2",
 #                  "hello", "10"],


### PR DESCRIPTION
I removed the new tests in run.py since it broke the CI and blocked any CI test from passing. I don't know anything about Jenkins and probably don't have access to it so I need to discuss with @jjhursey. I also need to figure out how to tell the run.py script where to find its files, master or elsewhere.
Removing these two tests should put the debug CI back to the working state it was in yesterday. 

I alo looked at the log for PR 2153 and it looks like the testcase wrote a line to stderr at the start of the run and threw off the sequence number for everything else. Also, it looks like the LAUNCH_COMPLETE event label got changed to READY-FOR-DEBUG by another change in a different pull request, so I need to look at that, both on Monday.
Signed-off-by: David Wootton <dwootton@us.ibm.com>