### PR TITLE
Update CI test scripts and baselines

### DIFF
--- a/prrte/debug/attach.stdout.baseline
+++ b/prrte/debug/attach.stdout.baseline
@@ -1,55 +1,55 @@
-attach    :001: Debugger ns @NS<0> rank 0 pid @PID<0>: Running
-attach    :002: evhandler_reg_callbk called to register callback refid=0
-attach    :003: attach_to_running_job called to attach to application with namespace=@NS<1>
-attach    :004: query_application_namespace called to get application namespace
-attach    :005: Application namespace is '@NS<2>'
-attach    :006: Spawn debugger daemon
-attach    :007: Debugger daemon namespace '@NS<3>'
-attach    :008: iof_reg_callbk called to register IOF handler refid=1
-attach    :009: evhandler_reg_callbk called to register callback refid=1
-attach    :010: Waiting for debugger daemon namespace @NS<3> to complete
-attach    :011: release_fn called as callback for event=JOB ENDED
-attach    :012: DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED - AFFECTED @NS<3>
-attach    :013: Debugger daemon namespace @NS<3> terminated
-attach    :014: PMIx_IOF_deregister completed with status SUCCESS
-attach    :015: iof_dereg_callbk called as reult of de-registering I/O forwarding, status SUCCESS
-attach    :016: Forwarded stdio data:
-attach    :017: End forwarded stdio
-daemon-0  :001: Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Running
-daemon-0  :001: Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Running
-daemon-0  :002: evhandler_reg_callbk called by daemon as registration callback
-daemon-0  :002: evhandler_reg_callbk called by daemon as registration callback
-daemon-0  :003: [@NS<3>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-0  :003: [@NS<3>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-0  :004: [@NS<3>:0:@PID<1>] Debugging '@NS<2>'
-daemon-0  :004: [@NS<3>:0:@PID<1>] Debugging '@NS<2>'
-daemon-0  :005: [@NS<3>:0:@PID<1>] my local rank 0
-daemon-0  :005: [@NS<3>:0:@PID<1>] my local rank 0
-daemon-0  :006: [@NS<3>:0:@PID<1>] registering for termination of '@NS<2>'
-daemon-0  :006: [@NS<3>:0:@PID<1>] registering for termination of '@NS<2>'
-daemon-0  :007: evhandler_reg_callbk called by daemon as registration callback
-daemon-0  :007: evhandler_reg_callbk called by daemon as registration callback
-daemon-0  :008: cbfunc called as daemon callback for PMIx_Query
-daemon-0  :008: cbfunc called as daemon callback for PMIx_Query
-daemon-0  :009: Transferring pmix.qry.lptable
-daemon-0  :009: Transferring pmix.qry.lptable
-daemon-0  :010: [@NS<3>:0:@PID<1>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-0  :010: [@NS<3>:0:@PID<1>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-0  :011: Proctable[0], namespace @NS<2> rank 0 exec hello
-daemon-0  :011: Proctable[0], namespace @NS<2> rank 0 exec hello
-daemon-0  :012: Proctable[1], namespace @NS<2> rank 1 exec hello
-daemon-0  :012: Proctable[1], namespace @NS<2> rank 1 exec hello
-daemon-0  :013: [@NS<3>:0:@PID<1>] Sending release
-daemon-0  :013: [@NS<3>:0:@PID<1>] Sending release
-daemon-0  :014: Waiting for application namespace @NS<2> to terminate
-daemon-0  :014: Waiting for application namespace @NS<2> to terminate
-daemon-0  :015: release_fn called as daemon callback for event=JOB ENDED
-daemon-0  :015: release_fn called as daemon callback for event=JOB ENDED
-daemon-0  :016: DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
-daemon-0  :016: DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
-daemon-0  :017: Application namespace @NS<2> terminated
-daemon-0  :017: Application namespace @NS<2> terminated
-daemon-0  :018: Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
-daemon-0  :018: Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
-daemon-0  :019: Debugger daemon ns @NS<3> rank 0 pid @PID<1>:PMIx_Finalize successfully completed
-daemon-0  :019: Debugger daemon ns @NS<3> rank 0 pid @PID<1>:PMIx_Finalize successfully completed
+attach    : Debugger ns @NS<0> rank 0 pid @PID<0>: Running
+attach    : evhandler_reg_callbk called to register callback refid=0
+attach    : attach_to_running_job called to attach to application with namespace=@NS<1>
+attach    : query_application_namespace called to get application namespace
+attach    : Application namespace is '@NS<2>'
+attach    : Spawn debugger daemon
+attach    : Debugger daemon namespace '@NS<3>'
+attach    : iof_reg_callbk called to register IOF handler refid=1
+attach    : evhandler_reg_callbk called to register callback refid=1
+attach    : Waiting for debugger daemon namespace @NS<3> to complete
+attach    : release_fn called as callback for event=JOB ENDED
+attach    : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED - AFFECTED @NS<3>
+attach    : Debugger daemon namespace @NS<3> terminated
+attach    : PMIx_IOF_deregister completed with status SUCCESS
+attach    : iof_dereg_callbk called as reult of de-registering I/O forwarding, status SUCCESS
+attach    : Forwarded stdio data:
+attach    : End forwarded stdio
+daemon-0  : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Running
+daemon-0  : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Running
+daemon-0  : evhandler_reg_callbk called by daemon as registration callback
+daemon-0  : evhandler_reg_callbk called by daemon as registration callback
+daemon-0  : [@NS<3>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-0  : [@NS<3>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-0  : [@NS<3>:0:@PID<1>] Debugging '@NS<2>'
+daemon-0  : [@NS<3>:0:@PID<1>] Debugging '@NS<2>'
+daemon-0  : [@NS<3>:0:@PID<1>] my local rank 0
+daemon-0  : [@NS<3>:0:@PID<1>] my local rank 0
+daemon-0  : [@NS<3>:0:@PID<1>] registering for termination of '@NS<2>'
+daemon-0  : [@NS<3>:0:@PID<1>] registering for termination of '@NS<2>'
+daemon-0  : evhandler_reg_callbk called by daemon as registration callback
+daemon-0  : evhandler_reg_callbk called by daemon as registration callback
+daemon-0  : cbfunc called as daemon callback for PMIx_Query
+daemon-0  : cbfunc called as daemon callback for PMIx_Query
+daemon-0  : Transferring pmix.qry.lptable
+daemon-0  : Transferring pmix.qry.lptable
+daemon-0  : [@NS<3>:0:@PID<1>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-0  : [@NS<3>:0:@PID<1>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-0  : Proctable[0], namespace @NS<2> rank 0 exec hello
+daemon-0  : Proctable[0], namespace @NS<2> rank 0 exec hello
+daemon-0  : Proctable[1], namespace @NS<2> rank 1 exec hello
+daemon-0  : Proctable[1], namespace @NS<2> rank 1 exec hello
+daemon-0  : [@NS<3>:0:@PID<1>] Sending release
+daemon-0  : [@NS<3>:0:@PID<1>] Sending release
+daemon-0  : Waiting for application namespace @NS<2> to terminate
+daemon-0  : Waiting for application namespace @NS<2> to terminate
+daemon-0  : release_fn called as daemon callback for event=JOB ENDED
+daemon-0  : release_fn called as daemon callback for event=JOB ENDED
+daemon-0  : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
+daemon-0  : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
+daemon-0  : Application namespace @NS<2> terminated
+daemon-0  : Application namespace @NS<2> terminated
+daemon-0  : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
+daemon-0  : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
+daemon-0  : Debugger daemon ns @NS<3> rank 0 pid @PID<1>:PMIx_Finalize successfully completed
+daemon-0  : Debugger daemon ns @NS<3> rank 0 pid @PID<1>:PMIx_Finalize successfully completed

--- a/prrte/debug/build.sh
+++ b/prrte/debug/build.sh
@@ -16,7 +16,7 @@ echo "Compiler: $PCC"
 echo ${PCC} --showme
 set -e
 
-gcc -o tcfilter tcfilter.c
+gcc -g -o tcfilter tcfilter.c
 if [ $? -ne 0 ] ; then
     echo "Compilation of tcfilter failed"
     exit 1

--- a/prrte/debug/direct.stdout.baseline
+++ b/prrte/debug/direct.stdout.baseline
@@ -1,45 +1,50 @@
-direct    :001: Debugger ns @NS<0> rank 0 pid @PID<0>: Running
-direct    :002: evhandler_reg_callbk called to register callback
-direct    :003: Called cbfunc as callback for PMIx_Query
-direct    :004: Key pmix.qry.spawn Type PMIX_STRING(3)
-direct    :005: Key pmix.qry.debug Type PMIX_STRING(3)
-direct    :006: Debugger: spawning hello
-direct    :007: evhandler_reg_callbk called to register callback
-direct    :008: Debugger: Registered for termination on nspace @NS<1>
-direct    :009: Called cbfunc as callback for PMIx_Query
-direct    :010: Key pmix.qry.ptable Type PMIX_DATA_ARRAY(39)
-direct    :011: Received proc table for 2 procs
-direct    :012: Calling spawn_debugger to spawn the debugger daemon
-direct    :013: Debugger: spawning ./daemon
-direct    :014: evhandler_reg_callbk called to register callback
-direct    :015: Debugger: Registered for termination on nspace @NS<2>
-hello-0   :001: Client ns @NS<1> rank 0 pid @PID<1>: Running on host @HOST<0> localrank 0
-hello-0   :002: Client ns @NS<1> rank 0: Finalizing
-daemon-0  :001: Debugger daemon ns @NS<2> rank 0 pid @PID<2>: Running
-daemon-0  :002: evhandler_reg_callbk called by daemon as registration callback
-hello-0   :003: Client ns @NS<1> rank 0:PMIx_Finalize successfully completed
-daemon-0  :003: [@NS<2>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-0  :004: [@NS<2>:0:@PID<2>] Debugging '@NS<1>'
-daemon-0  :005: [@NS<2>:0:@PID<2>] my local rank 0
-daemon-0  :006: [@NS<2>:0:@PID<2>] registering for termination of '@NS<1>'
-daemon-0  :007: evhandler_reg_callbk called by daemon as registration callback
-daemon-0  :008: cbfunc called as daemon callback for PMIx_Query
-daemon-0  :009: Transferring pmix.qry.lptable
-daemon-0  :010: [@NS<2>:0:@PID<2>] Local proctable received for nspace '@NS<1>' has 2 entries
-daemon-0  :011: Proctable[0], namespace @NS<1> rank 0 exec hello
-daemon-0  :012: Proctable[1], namespace @NS<1> rank 1 exec hello
-daemon-0  :013: [@NS<2>:0:@PID<2>] Sending release
-daemon-0  :014: Waiting for application namespace @NS<1> to terminate
-hello-1   :001: Client ns @NS<1> rank 1 pid @PID<3>: Running on host @HOST<0> localrank 1
-hello-1   :002: Client ns @NS<1> rank 1: Finalizing
-hello-1   :003: Client ns @NS<1> rank 1:PMIx_Finalize successfully completed
-direct    :016: release_fn called as callback for event=JOB ENDED source=@NS<1>:0
-direct    :017: DEBUGGER NOTIFIED THAT JOB @NS<1> TERMINATED
-daemon-0  :015: release_fn called as daemon callback for event=JOB ENDED
-daemon-0  :016: DEBUGGER DAEMON NAMESPACE @NS<2> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
-daemon-0  :017: Application namespace @NS<1> terminated
-daemon-0  :018: Debugger daemon ns @NS<2> rank 0 pid @PID<2>: Finalizing
-daemon-0  :019: Debugger daemon ns @NS<2> rank 0 pid @PID<2>:PMIx_Finalize successfully completed
-direct    :018: release_fn called as callback for event=JOB ENDED source=@NS<2>:0
-direct    :019: DEBUGGER NOTIFIED THAT JOB @NS<2> TERMINATED
-0
+daemon-0  : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Running
+daemon-0  : evhandler_reg_callbk called by daemon as registration callback
+daemon-0  : [@NS<0>:-2:@PID<0>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-0  : [@NS<0>:0:@PID<0>] Debugging '@NS<1>'
+daemon-0  : [@NS<0>:0:@PID<0>] my local rank 0
+daemon-0  : [@NS<0>:0:@PID<0>] registering for termination of '@NS<1>'
+daemon-0  : evhandler_reg_callbk called by daemon as registration callback
+daemon-0  : cbfunc called as daemon callback for PMIx_Query
+daemon-0  : Transferring pmix.qry.lptable
+daemon-0  : [@NS<0>:0:@PID<0>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-0  : Proctable[0], namespace @NS<1> rank 0 exec hello
+daemon-0  : Proctable[1], namespace @NS<1> rank 1 exec hello
+daemon-0  : [@NS<0>:0:@PID<0>] Sending release
+daemon-0  : Waiting for application namespace @NS<1> to terminate
+daemon-0  : release_fn called as daemon callback for event=JOB ENDED
+daemon-0  : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
+daemon-0  : Application namespace @NS<1> terminated
+daemon-0  : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Finalizing
+daemon-0  : Debugger daemon ns @NS<0> rank 0 pid @PID<0>:PMIx_Finalize successfully completed
+direct    : Debugger ns @NS<2> rank 0 pid @PID<1>: Running
+direct    : Connected system server is @NS<3>:0
+direct    : evhandler_reg_callbk called to register callback
+direct    : Called cbfunc as callback for PMIx_Query
+direct    : Key pmix.qry.spawn Type PMIX_STRING(3)
+direct    : Key pmix.qry.debug Type PMIX_STRING(3)
+direct    : Debugger: spawning hello
+direct    : evhandler_reg_callbk called to register callback
+direct    : Debugger: Registered for termination on nspace @NS<1>
+direct    : evhandler_reg_callbk called to register callback
+direct    : Debugger: Registered for READY_FOR_DEBUG event for nspace @NS<3>
+direct    : Waiting for PMIX_READY_FOR_DEBUG event to be posted
+direct    : debug_ready_cb called for event notification READY-FOR-DEBUG from nspace @NS<3>
+direct    : Got READY-FOR-DEBUG notification for target nspace @NS<1>
+direct    : Called cbfunc as callback for PMIx_Query
+direct    : Key pmix.qry.ptable Type PMIX_DATA_ARRAY(39)
+direct    : Received proc table for 2 procs
+direct    : Calling spawn_debugger to spawn the debugger daemon
+direct    : Debugger: spawning ./daemon
+direct    : evhandler_reg_callbk called to register callback
+direct    : Debugger: Registered for termination on nspace @NS<0>
+direct    : release_fn called as callback for event=JOB ENDED source=@NS<1>:0
+direct    : DEBUGGER NOTIFIED THAT JOB @NS<1> TERMINATED 
+direct    : release_fn called as callback for event=JOB ENDED source=@NS<0>:0
+direct    : DEBUGGER NOTIFIED THAT JOB @NS<0> TERMINATED 
+hello-0   : Client ns @NS<1> rank 0 pid @PID<2>: Running on host @HOST<0> localrank 0
+hello-0   : Client ns @NS<1> rank 0: Finalizing
+hello-0   : Client ns @NS<1> rank 0:PMIx_Finalize successfully completed
+hello-1   : Client ns @NS<1> rank 1 pid @PID<3>: Running on host @HOST<0> localrank 1
+hello-1   : Client ns @NS<1> rank 1: Finalizing
+hello-1   : Client ns @NS<1> rank 1:PMIx_Finalize successfully completed

--- a/prrte/debug/indirect-prterun.stdout.baseline
+++ b/prrte/debug/indirect-prterun.stdout.baseline
@@ -1,44 +1,43 @@
-indirect  :001: Debugger ns @NS<0> rank 0 pid @PID<0>: Running
-indirect  :002: DEBUGGER URI: @NS<1>;tcp4://@HOST<0>
-indirect  :003: evhandler_reg_callbk called with status SUCCESS
-indirect  :004: evhandler_reg_callbk called with status SUCCESS
-indirect  :005: SPAWNING LAUNCHER
-indirect  :006: RECONNECT TO IL AT @NS<2>
-indirect  :007: REGISTERING READY-FOR-DEBUG HANDLER
-indirect  :008: evhandler_reg_callbk called with status SUCCESS
-indirect  :009: RELEASING prterun [@NS<3>]
-indirect  :010: WAITING FOR APPLICATION LAUNCH
-indirect  :011: dbactive=1 ilactive=1 (icount 0)
-indirect  :012: GOT NSPACE @HOST<1>:@PID<0>:@NS<4>
-indirect  :013: Debugger daemon job: @HOST<1>:@PID<0>:@NS<4>
-indirect  :014: APPLICATION HAS LAUNCHED: @HOST<1>:@PID<0>:@NS<4>
-indirect  :015: Debugger: spawning ./daemon
-indirect  :016: WAITING FOR IL TO TERMINATE
-daemon-0  :001: Debugger daemon ns @HOST<1>:@PID<0>:@NS<5> rank 0 pid @PID<1>: Running
-daemon-0  :002: evhandler_reg_callbk called by daemon as registration callback
-daemon-0  :003: [@HOST<1>:@PID<0>:@NS<6>@2:-2:@PID<1>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<0>:@NS<4>'
-daemon-0  :004: [@HOST<1>:@PID<0>:@NS<6>@2:0:@PID<1>] Debugging '@HOST<1>:@PID<0>:@NS<4>'
-daemon-0  :005: [@HOST<1>:@PID<0>:@NS<6>@2:0:@PID<1>] my local rank 0
-daemon-0  :006: [@HOST<1>:@PID<0>:@NS<6>@2:0:@PID<1>] registering for termination of '@HOST<1>:@PID<0>:@NS<4>'
-daemon-0  :007: evhandler_reg_callbk called by daemon as registration callback
-daemon-0  :008: cbfunc called as daemon callback for PMIx_Query
-daemon-0  :009: Transferring pmix.qry.lptable
-daemon-0  :010: [@HOST<1>:@PID<0>:@NS<6>@2:0:@PID<1>] Local proctable received for nspace '@HOST<1>:@PID<0>:@NS<4>' has 2 entries
-daemon-0  :011: Proctable[0], namespace @HOST<1>:@PID<0>:@NS<4> rank 0 exec hello
-daemon-0  :012: Proctable[1], namespace @HOST<1>:@PID<0>:@NS<4> rank 1 exec hello
-daemon-0  :013: [@HOST<1>:@PID<0>:@NS<6>@2:0:@PID<1>] Sending release
-daemon-0  :014: Waiting for application namespace @HOST<1>:@PID<0>:@NS<4> to terminate
-hello-0   :001: Client ns @HOST<1>:@PID<0>:@NS<4> rank 0 pid @PID<2>: Running on host @HOST<2> localrank 0
-hello-1   :001: Client ns @HOST<1>:@PID<0>:@NS<4> rank 1 pid @PID<3>: Running on host @HOST<2> localrank 1
-hello-1   :002: Client ns @HOST<1>:@PID<0>:@NS<4> rank 1: Finalizing
-hello-1   :003: Client ns @HOST<1>:@PID<0>:@NS<4> rank 1:PMIx_Finalize successfully completed
-hello-0   :002: Client ns @HOST<1>:@PID<0>:@NS<4> rank 0: Finalizing
-hello-0   :003: Client ns @HOST<1>:@PID<0>:@NS<4> rank 0:PMIx_Finalize successfully completed
-daemon-0  :015: release_fn called as daemon callback for event=JOB ENDED
-daemon-0  :016: DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<0>:@NS<5> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<0>:@NS<4>
-daemon-0  :017: Application namespace @HOST<1>:@PID<0>:@NS<4> terminated
-daemon-0  :018: Debugger daemon ns @HOST<1>:@PID<0>:@NS<5> rank 0 pid @PID<1>: Finalizing
-daemon-0  :019: Debugger daemon ns @HOST<1>:@PID<0>:@NS<5> rank 0 pid @PID<1>:PMIx_Finalize successfully completed
-indirect  :017: terminate_fn called with status LOST_CONNECTION
-indirect  :018: DEFAULT EVENT HANDLER CALLED WITH STATUS LOST_CONNECTION
-indirect  :019: 	COMPLETE
+daemon-0  : Debugger daemon ns @HOST<0>:@PID<1>:@NS<0> rank 0 pid @PID<0>: Running
+daemon-0  : evhandler_reg_callbk called by daemon as registration callback
+daemon-0  : [@HOST<0>:@PID<1>:@NS<1>@2:-2:@PID<0>] PMIX_DEBUG_JOB is '@HOST<0>:@PID<1>:@NS<2>'
+daemon-0  : [@HOST<0>:@PID<1>:@NS<1>@2:0:@PID<0>] Debugging '@HOST<0>:@PID<1>:@NS<2>'
+daemon-0  : [@HOST<0>:@PID<1>:@NS<1>@2:0:@PID<0>] my local rank 0
+daemon-0  : [@HOST<0>:@PID<1>:@NS<1>@2:0:@PID<0>] registering for termination of '@HOST<0>:@PID<1>:@NS<2>'
+daemon-0  : evhandler_reg_callbk called by daemon as registration callback
+daemon-0  : cbfunc called as daemon callback for PMIx_Query
+daemon-0  : Transferring pmix.qry.lptable
+daemon-0  : [@HOST<0>:@PID<1>:@NS<1>@2:0:@PID<0>] Local proctable received for nspace '@HOST<0>:@PID<1>:@NS<2>' has 2 entries
+daemon-0  : Proctable[0], namespace @HOST<0>:@PID<1>:@NS<2> rank 0 exec hello
+daemon-0  : Proctable[1], namespace @HOST<0>:@PID<1>:@NS<2> rank 1 exec hello
+daemon-0  : [@HOST<0>:@PID<1>:@NS<1>@2:0:@PID<0>] Sending release
+daemon-0  : Waiting for application namespace @HOST<0>:@PID<1>:@NS<2> to terminate
+daemon-0  : release_fn called as daemon callback for event=JOB ENDED
+daemon-0  : DEBUGGER DAEMON NAMESPACE @HOST<0>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<0>:@PID<1>:@NS<2>
+daemon-0  : Application namespace @HOST<0>:@PID<1>:@NS<2> terminated
+daemon-0  : Debugger daemon ns @HOST<0>:@PID<1>:@NS<0> rank 0 pid @PID<0>: Finalizing
+daemon-0  : Debugger daemon ns @HOST<0>:@PID<1>:@NS<0> rank 0 pid @PID<0>:PMIx_Finalize successfully completed
+hello-0   : Client ns @HOST<0>:@PID<1>:@NS<2> rank 0 pid @PID<2>: Running on host @HOST<0> localrank 0
+hello-0   : Client ns @HOST<0>:@PID<1>:@NS<2> rank 0: Finalizing
+hello-0   : Client ns @HOST<0>:@PID<1>:@NS<2> rank 0:PMIx_Finalize successfully completed
+hello-1   : Client ns @HOST<0>:@PID<1>:@NS<2> rank 1 pid @PID<3>: Running on host @HOST<0> localrank 1
+hello-1   : Client ns @HOST<0>:@PID<1>:@NS<2> rank 1: Finalizing
+hello-1   : Client ns @HOST<0>:@PID<1>:@NS<2> rank 1:PMIx_Finalize successfully completed
+indirect  : Debugger ns @NS<3> rank 0 pid @PID<1>: Running
+indirect  : DEBUGGER URI: @NS<4>;tcp4://@HOST<1>
+indirect  : evhandler_reg_callbk called with status SUCCESS
+indirect  : evhandler_reg_callbk called with status SUCCESS
+indirect  : SPAWNING LAUNCHER
+indirect  : RECONNECT TO IL AT @NS<5>
+indirect  : REGISTERING READY-FOR-DEBUG HANDLER
+indirect  : evhandler_reg_callbk called with status SUCCESS
+indirect  : RELEASING prterun [@NS<6>]
+indirect  : WAITING FOR APPLICATION LAUNCH
+indirect  : GOT NSPACE @HOST<0>:@PID<1>:@NS<2>
+indirect  : Debugger daemon job: @HOST<0>:@PID<1>:@NS<2>
+indirect  : APPLICATION HAS LAUNCHED: @HOST<0>:@PID<1>:@NS<2>
+indirect  : Debugger: spawning ./daemon
+indirect  : WAITING FOR IL TO TERMINATE
+indirect  : terminate_fn called with status LOST_CONNECTION
+indirect  : DEFAULT EVENT HANDLER CALLED WITH STATUS LOST_CONNECTION
+indirect  : 	COMPLETE

--- a/prrte/debug/tcfilter.c
+++ b/prrte/debug/tcfilter.c
@@ -206,6 +206,11 @@ int main(int argc, char *argv[]) {
       // Read testcase output from stdin and write converted text to stdout
     char *p = fgets(input, sizeof input - 1, stdin);
     while (NULL != p) {
+        // Remove sequence numbers from stdout/stderr file since they cause all
+        // following lines to fail comparison to baseline when a line is added or
+        // deleted in output for current execution. That masks the real
+        // difference in output.
+        memmove(&input[10], &input[14], strlen(&input[14]));
         int rescan;
           // Get rid of newline since puts() will add a newline to output string
         p = strchr(input, '\n');


### PR DESCRIPTION
Update tcfilter.c to remove line sequence numbering from stdout/stderr. If the differences from a baseline included new or missing lines, then the change in line numbering caused all subsequent lines to differ, adding useless clutter to the diff output

Update run.py to write original stdout and stderr to files with .orig suffix to aid in debugging a test case failure

Update build.sh to compile tests with -g flag

Update baselines due to removing line sequencing and changes to handle PRTE_READY_FOR_DEBUG event.

This pull request is co-requisite with PRRTE pull request #909
