### PR TITLE
Temporarily remove the v4.0 branch from PMIx xversion

### DIFF
--- a/crossversion/xversion.py
+++ b/crossversion/xversion.py
@@ -15,7 +15,7 @@ import subprocess
 import shutil
 
 # put this in one place
-supported_versions = ["master", "v4.0", "v3.1", "v3.2"]
+supported_versions = ["master", "v3.1", "v3.2"]
 
 pmix_git_url      = "https://github.com/pmix/pmix.git"
 pmix_release_url  = "https://github.com/pmix/pmix/releases/download/"


### PR DESCRIPTION
Need to disable it while we convert to the v4.1 branch

Signed-off-by: Ralph Castain <rhc@pmix.org>