### PR TITLE
Update baselines to match current PRRTE debugger testcases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ prrte/hello_world/output.txt
 prrte/hello_world/output-hn.txt
 prrte/cycle/output.txt
 prrte/cycle/init_finalize_pmix
+prrte/cycle/dvm.uri
 prrte/prun-wrapper/output*.txt
 prrte/prun-wrapper/bin
 prrte/debug/attach
@@ -105,3 +106,5 @@ prrte/debug/direct-cospawn.stderr
 prrte/debug/direct-cospawn.stdout
 prrte/debug/direct.stderr
 prrte/debug/direct.stdout
+prrte/manystress/sleeper
+prrte/manystress/output.txt

--- a/prrte/cycle/run.sh
+++ b/prrte/cycle/run.sh
@@ -26,9 +26,11 @@ if [ "x" = "x$CI_HOSTFILE" ] ; then
 else
     hostarg="--hostfile $CI_HOSTFILE"
 fi
-
+rm -f dvm.uri
+echo "======================="
+echo "Starting DVM: prte --no-ready-msg --report-uri dvm.uri $hostarg &"
+echo "======================="
 prte --no-ready-msg --report-uri dvm.uri $hostarg &
-
 
 # ---------------------------------------
 # Run the test - hostname
@@ -38,7 +40,7 @@ echo "======================="
 echo "Running hostname: $_CMD"
 echo "======================="
 
-rm output.txt ; touch output.txt
+rm -f output.txt ; touch output.txt
 for n in $(seq 1 $NUM_ITERS) ; do
     echo -e "--------------------- Execution (hostname): $n"
     $_CMD 2>&1 | tee -a output.txt
@@ -81,7 +83,7 @@ echo "======================="
 echo "Running init_finalize_pmix: $_CMD"
 echo "======================="
 
-rm output.txt ; touch output.txt
+rm -f output.txt ; touch output.txt
 for n in $(seq 1 $NUM_ITERS) ; do
     echo -e "--------------------- Execution (init/finalize): $n"
     $_CMD 2>&1 | tee -a output.txt

--- a/prrte/cycle/run.sh
+++ b/prrte/cycle/run.sh
@@ -73,6 +73,14 @@ fi
 if [ $FINAL_RTN == 0 ] ; then
     echo "Success - hostname"
 fi
+_shutdown
+
+
+rm -f dvm.uri
+echo "======================="
+echo "Starting DVM: prte --no-ready-msg --report-uri dvm.uri $hostarg &"
+echo "======================="
+prte --no-ready-msg --report-uri dvm.uri $hostarg &
 
 # ---------------------------------------
 # Run the test - init_finalize

--- a/prrte/cycle/run.sh
+++ b/prrte/cycle/run.sh
@@ -13,7 +13,7 @@ _shutdown()
     # ---------------------------------------
     # Cleanup DVM
     # ---------------------------------------
-    pterm
+    pterm --dvm-uri file:dvm.uri
 
     exit $FINAL_RTN
 }
@@ -22,19 +22,18 @@ _shutdown()
 # Start the DVM
 # ---------------------------------------
 if [ "x" = "x$CI_HOSTFILE" ] ; then
-    prte --daemonize
+    hostarg=
 else
-    prte --daemonize --hostfile $CI_HOSTFILE
+    hostarg="--hostfile $CI_HOSTFILE"
 fi
 
-# Wait for DVM to start
-sleep 5
+prte --no-ready-msg --report-uri dvm.uri $hostarg &
 
 
 # ---------------------------------------
 # Run the test - hostname
 # ---------------------------------------
-_CMD="prun -n 1 hostname"
+_CMD="prun --dvm-uri file:dvm.uri --num-connect-retries 1000 -n 1 hostname"
 echo "======================="
 echo "Running hostname: $_CMD"
 echo "======================="
@@ -76,7 +75,7 @@ fi
 # ---------------------------------------
 # Run the test - init_finalize
 # ---------------------------------------
-_CMD="prun ./init_finalize_pmix"
+_CMD="prun --dvm-uri file:dvm.uri --num-connect-retries 1000 ./init_finalize_pmix"
 echo ""
 echo "======================="
 echo "Running init_finalize_pmix: $_CMD"

--- a/prrte/cycle/run.sh
+++ b/prrte/cycle/run.sh
@@ -73,7 +73,7 @@ fi
 if [ $FINAL_RTN == 0 ] ; then
     echo "Success - hostname"
 fi
-_shutdown
+pterm --dvm-uri file:dvm.uri
 
 
 rm -f dvm.uri

--- a/prrte/debug/attach-colaunch1.stdout.baseline
+++ b/prrte/debug/attach-colaunch1.stdout.baseline
@@ -8,11 +8,10 @@ attach              : Debugger daemon namespace '@NS<3>'
 attach              : iof_reg_callbk called to register IOF handler refid=1
 attach              : evhandler_reg_callbk called to register callback refid=1
 attach              : Waiting for debugger daemon namespace @NS<3> to complete
-attach              : release_fn called as callback for event=JOB ENDED
-attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED - AFFECTED @NS<3>
+attach              : launcher_done called as callback for event=LOST_CONNECTION
+attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED
+attach              : notification_fn called as callback for event=LOST_CONNECTION
 attach              : Debugger daemon namespace @NS<3> terminated
-attach              : PMIx_IOF_deregister completed with status SUCCESS
-attach              : iof_dereg_callbk called as result of de-registering I/O forwarding
 attach              : Forwarded stdio data:
 attach              : End forwarded stdio
 daemon-0            : Debugger daemon ns @NS<3> on host @HOST<0> rank 0 pid @PID<1>: Running
@@ -51,8 +50,6 @@ daemon-0            : Application namespace @NS<2> terminated
 daemon-0            : Application namespace @NS<2> terminated
 daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
 daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
-daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>:PMIx_Finalize successfully completed
-daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>:PMIx_Finalize successfully completed
 daemon-1            : Debugger daemon ns @NS<3> on host @HOST<1> rank 1 pid @PID<2>: Running
 daemon-1            : Debugger daemon ns @NS<3> on host @HOST<1> rank 1 pid @PID<2>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
@@ -87,8 +84,6 @@ daemon-1            : Application namespace @NS<2> terminated
 daemon-1            : Application namespace @NS<2> terminated
 daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>: Finalizing
 daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>: Finalizing
-daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>:PMIx_Finalize successfully completed
-daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>:PMIx_Finalize successfully completed
 daemon-2            : Debugger daemon ns @NS<3> on host @HOST<2> rank 2 pid @PID<3>: Running
 daemon-2            : Debugger daemon ns @NS<3> on host @HOST<2> rank 2 pid @PID<3>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
@@ -123,5 +118,3 @@ daemon-2            : Application namespace @NS<2> terminated
 daemon-2            : Application namespace @NS<2> terminated
 daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>: Finalizing
 daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>: Finalizing
-daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>:PMIx_Finalize successfully completed
-daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>:PMIx_Finalize successfully completed

--- a/prrte/debug/attach-colaunch1.stdout.baseline
+++ b/prrte/debug/attach-colaunch1.stdout.baseline
@@ -8,9 +8,8 @@ attach              : Debugger daemon namespace '@NS<3>'
 attach              : iof_reg_callbk called to register IOF handler refid=1
 attach              : evhandler_reg_callbk called to register callback refid=1
 attach              : Waiting for debugger daemon namespace @NS<3> to complete
-attach              : launcher_done called as callback for event=LOST_CONNECTION
-attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED
-attach              : notification_fn called as callback for event=LOST_CONNECTION
+attach              : release_fn called as callback for event=LOST_CONNECTION
+attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED - AFFECTED NULL
 attach              : Debugger daemon namespace @NS<3> terminated
 attach              : Forwarded stdio data:
 attach              : End forwarded stdio

--- a/prrte/debug/attach-colaunch2.stdout.baseline
+++ b/prrte/debug/attach-colaunch2.stdout.baseline
@@ -8,11 +8,10 @@ attach              : Debugger daemon namespace '@NS<3>'
 attach              : iof_reg_callbk called to register IOF handler refid=1
 attach              : evhandler_reg_callbk called to register callback refid=1
 attach              : Waiting for debugger daemon namespace @NS<3> to complete
-attach              : release_fn called as callback for event=JOB ENDED
-attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED - AFFECTED @NS<3>
+attach              : launcher_done called as callback for event=LOST_CONNECTION
+attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED
+attach              : notification_fn called as callback for event=LOST_CONNECTION
 attach              : Debugger daemon namespace @NS<3> terminated
-attach              : PMIx_IOF_deregister completed with status SUCCESS
-attach              : iof_dereg_callbk called as result of de-registering I/O forwarding
 attach              : Forwarded stdio data:
 attach              : End forwarded stdio
 daemon-0            : Debugger daemon ns @NS<3> on host @HOST<0> rank 0 pid @PID<1>: Running
@@ -51,8 +50,6 @@ daemon-0            : Application namespace @NS<2> terminated
 daemon-0            : Application namespace @NS<2> terminated
 daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
 daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
-daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>:PMIx_Finalize successfully completed
-daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>:PMIx_Finalize successfully completed
 daemon-1            : Debugger daemon ns @NS<3> on host @HOST<0> rank 1 pid @PID<2>: Running
 daemon-1            : Debugger daemon ns @NS<3> on host @HOST<0> rank 1 pid @PID<2>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
@@ -87,8 +84,6 @@ daemon-1            : Application namespace @NS<2> terminated
 daemon-1            : Application namespace @NS<2> terminated
 daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>: Finalizing
 daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>: Finalizing
-daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>:PMIx_Finalize successfully completed
-daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>:PMIx_Finalize successfully completed
 daemon-2            : Debugger daemon ns @NS<3> on host @HOST<1> rank 2 pid @PID<3>: Running
 daemon-2            : Debugger daemon ns @NS<3> on host @HOST<1> rank 2 pid @PID<3>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
@@ -123,8 +118,6 @@ daemon-2            : Application namespace @NS<2> terminated
 daemon-2            : Application namespace @NS<2> terminated
 daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>: Finalizing
 daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>: Finalizing
-daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>:PMIx_Finalize successfully completed
-daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>:PMIx_Finalize successfully completed
 daemon-3            : Debugger daemon ns @NS<3> on host @HOST<1> rank 3 pid @PID<4>: Running
 daemon-3            : Debugger daemon ns @NS<3> on host @HOST<1> rank 3 pid @PID<4>: Running
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
@@ -159,8 +152,6 @@ daemon-3            : Application namespace @NS<2> terminated
 daemon-3            : Application namespace @NS<2> terminated
 daemon-3            : Debugger daemon ns @NS<3> rank 3 pid @PID<4>: Finalizing
 daemon-3            : Debugger daemon ns @NS<3> rank 3 pid @PID<4>: Finalizing
-daemon-3            : Debugger daemon ns @NS<3> rank 3 pid @PID<4>:PMIx_Finalize successfully completed
-daemon-3            : Debugger daemon ns @NS<3> rank 3 pid @PID<4>:PMIx_Finalize successfully completed
 daemon-4            : Debugger daemon ns @NS<3> on host @HOST<2> rank 4 pid @PID<5>: Running
 daemon-4            : Debugger daemon ns @NS<3> on host @HOST<2> rank 4 pid @PID<5>: Running
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
@@ -195,8 +186,6 @@ daemon-4            : Application namespace @NS<2> terminated
 daemon-4            : Application namespace @NS<2> terminated
 daemon-4            : Debugger daemon ns @NS<3> rank 4 pid @PID<5>: Finalizing
 daemon-4            : Debugger daemon ns @NS<3> rank 4 pid @PID<5>: Finalizing
-daemon-4            : Debugger daemon ns @NS<3> rank 4 pid @PID<5>:PMIx_Finalize successfully completed
-daemon-4            : Debugger daemon ns @NS<3> rank 4 pid @PID<5>:PMIx_Finalize successfully completed
 daemon-5            : Debugger daemon ns @NS<3> on host @HOST<2> rank 5 pid @PID<6>: Running
 daemon-5            : Debugger daemon ns @NS<3> on host @HOST<2> rank 5 pid @PID<6>: Running
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
@@ -231,5 +220,3 @@ daemon-5            : Application namespace @NS<2> terminated
 daemon-5            : Application namespace @NS<2> terminated
 daemon-5            : Debugger daemon ns @NS<3> rank 5 pid @PID<6>: Finalizing
 daemon-5            : Debugger daemon ns @NS<3> rank 5 pid @PID<6>: Finalizing
-daemon-5            : Debugger daemon ns @NS<3> rank 5 pid @PID<6>:PMIx_Finalize successfully completed
-daemon-5            : Debugger daemon ns @NS<3> rank 5 pid @PID<6>:PMIx_Finalize successfully completed

--- a/prrte/debug/attach-colaunch2.stdout.baseline
+++ b/prrte/debug/attach-colaunch2.stdout.baseline
@@ -8,9 +8,8 @@ attach              : Debugger daemon namespace '@NS<3>'
 attach              : iof_reg_callbk called to register IOF handler refid=1
 attach              : evhandler_reg_callbk called to register callback refid=1
 attach              : Waiting for debugger daemon namespace @NS<3> to complete
-attach              : launcher_done called as callback for event=LOST_CONNECTION
-attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED
-attach              : notification_fn called as callback for event=LOST_CONNECTION
+attach              : release_fn called as callback for event=LOST_CONNECTION
+attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED - AFFECTED NULL
 attach              : Debugger daemon namespace @NS<3> terminated
 attach              : Forwarded stdio data:
 attach              : End forwarded stdio

--- a/prrte/debug/attach.stdout.baseline
+++ b/prrte/debug/attach.stdout.baseline
@@ -8,11 +8,10 @@ attach              : Debugger daemon namespace '@NS<3>'
 attach              : iof_reg_callbk called to register IOF handler refid=1
 attach              : evhandler_reg_callbk called to register callback refid=1
 attach              : Waiting for debugger daemon namespace @NS<3> to complete
-attach              : release_fn called as callback for event=JOB ENDED
-attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED - AFFECTED @NS<3>
+attach              : launcher_done called as callback for event=LOST_CONNECTION
+attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED
+attach              : notification_fn called as callback for event=LOST_CONNECTION
 attach              : Debugger daemon namespace @NS<3> terminated
-attach              : PMIx_IOF_deregister completed with status SUCCESS
-attach              : iof_dereg_callbk called as result of de-registering I/O forwarding
 attach              : Forwarded stdio data:
 attach              : End forwarded stdio
 daemon-0            : Debugger daemon ns @NS<3> on host @HOST<0> rank 0 pid @PID<1>: Running
@@ -51,5 +50,3 @@ daemon-0            : Application namespace @NS<2> terminated
 daemon-0            : Application namespace @NS<2> terminated
 daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
 daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
-daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>:PMIx_Finalize successfully completed
-daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>:PMIx_Finalize successfully completed

--- a/prrte/debug/attach.stdout.baseline
+++ b/prrte/debug/attach.stdout.baseline
@@ -8,9 +8,8 @@ attach              : Debugger daemon namespace '@NS<3>'
 attach              : iof_reg_callbk called to register IOF handler refid=1
 attach              : evhandler_reg_callbk called to register callback refid=1
 attach              : Waiting for debugger daemon namespace @NS<3> to complete
-attach              : launcher_done called as callback for event=LOST_CONNECTION
-attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED
-attach              : notification_fn called as callback for event=LOST_CONNECTION
+attach              : release_fn called as callback for event=LOST_CONNECTION
+attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED - AFFECTED NULL
 attach              : Debugger daemon namespace @NS<3> terminated
 attach              : Forwarded stdio data:
 attach              : End forwarded stdio

--- a/prrte/debug/build.sh
+++ b/prrte/debug/build.sh
@@ -35,7 +35,7 @@ do
         echo "Compilation of test-utils failed"
         exit 1
     fi
-    ${PCC} -Wall -g -o ${program} -I${CI_PRRTE_SRC}/examples/debugger ${CI_PRRTE_SRC}/examples/debugger/${program}.c test-utils.o -ldl
+    ${PCC} -Wall -g -o ${program} -I${CI_PRRTE_SRC}/examples/debugger ${CI_PRRTE_SRC}/examples/debugger/${program}.c test-utils.o -ldl 
     if [ $? -ne 0 ] ; then
         echo "Compilation of $program failed"
         exit 1

--- a/prrte/debug/cirun.py
+++ b/prrte/debug/cirun.py
@@ -11,7 +11,7 @@ from time import strftime
 # The first element in each row is the number of slots, and the remaining 
 # elements are the names of the run.py testcases needing that number of slots
 tests = [ ["1", "direct", "attach", "indirect-prterun"],
-          ["2", "direct-colaunch1", "direct-colaunch1", "direct-colaunch2",
+          ["2", "direct-colaunch1", "direct-colaunch2",
                 "attach-colaunch1", "attach-colaunch2"],
           ["3", "direct-multi"],
           ["4", "indirect-colaunch1", "indirect-colaunch2"],

--- a/prrte/debug/direct-colaunch1.stdout.baseline
+++ b/prrte/debug/direct-colaunch1.stdout.baseline
@@ -16,7 +16,6 @@ daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-0            : Application namespace @NS<1> terminated
 daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>:PMIx_Finalize successfully completed
 daemon-1            : Debugger daemon ns @NS<0> on host @HOST<1> rank 1 pid @PID<1>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : [@NS<0>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<1>'
@@ -34,7 +33,6 @@ daemon-1            : release_fn called as daemon callback for event=JOB ENDED
 daemon-1            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-1            : Application namespace @NS<1> terminated
 daemon-1            : Debugger daemon ns @NS<0> rank 1 pid @PID<1>: Finalizing
-daemon-1            : Debugger daemon ns @NS<0> rank 1 pid @PID<1>:PMIx_Finalize successfully completed
 daemon-2            : Debugger daemon ns @NS<0> on host @HOST<2> rank 2 pid @PID<2>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : [@NS<0>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<1>'
@@ -52,7 +50,6 @@ daemon-2            : release_fn called as daemon callback for event=JOB ENDED
 daemon-2            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-2            : Application namespace @NS<1> terminated
 daemon-2            : Debugger daemon ns @NS<0> rank 2 pid @PID<2>: Finalizing
-daemon-2            : Debugger daemon ns @NS<0> rank 2 pid @PID<2>:PMIx_Finalize successfully completed
 direct-multi        : Debugger ns @NS<2> rank 0 pid @PID<3>: Running
 direct-multi        : evhandler_reg_callbk called to register callback
 direct-multi        : Called cbfunc as callback for PMIx_Query

--- a/prrte/debug/direct-colaunch2.stdout.baseline
+++ b/prrte/debug/direct-colaunch2.stdout.baseline
@@ -16,7 +16,6 @@ daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-0            : Application namespace @NS<1> terminated
 daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>:PMIx_Finalize successfully completed
 daemon-1            : Debugger daemon ns @NS<0> on host @HOST<0> rank 1 pid @PID<1>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : [@NS<0>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<1>'
@@ -34,7 +33,6 @@ daemon-1            : release_fn called as daemon callback for event=JOB ENDED
 daemon-1            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-1            : Application namespace @NS<1> terminated
 daemon-1            : Debugger daemon ns @NS<0> rank 1 pid @PID<1>: Finalizing
-daemon-1            : Debugger daemon ns @NS<0> rank 1 pid @PID<1>:PMIx_Finalize successfully completed
 daemon-2            : Debugger daemon ns @NS<0> on host @HOST<1> rank 2 pid @PID<2>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : [@NS<0>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<1>'
@@ -52,7 +50,6 @@ daemon-2            : release_fn called as daemon callback for event=JOB ENDED
 daemon-2            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-2            : Application namespace @NS<1> terminated
 daemon-2            : Debugger daemon ns @NS<0> rank 2 pid @PID<2>: Finalizing
-daemon-2            : Debugger daemon ns @NS<0> rank 2 pid @PID<2>:PMIx_Finalize successfully completed
 daemon-3            : Debugger daemon ns @NS<0> on host @HOST<1> rank 3 pid @PID<3>: Running
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
 daemon-3            : [@NS<0>:-2:@PID<3>] PMIX_DEBUG_JOB is '@NS<1>'
@@ -70,7 +67,6 @@ daemon-3            : release_fn called as daemon callback for event=JOB ENDED
 daemon-3            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-3            : Application namespace @NS<1> terminated
 daemon-3            : Debugger daemon ns @NS<0> rank 3 pid @PID<3>: Finalizing
-daemon-3            : Debugger daemon ns @NS<0> rank 3 pid @PID<3>:PMIx_Finalize successfully completed
 daemon-4            : Debugger daemon ns @NS<0> on host @HOST<2> rank 4 pid @PID<4>: Running
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
 daemon-4            : [@NS<0>:-2:@PID<4>] PMIX_DEBUG_JOB is '@NS<1>'
@@ -88,7 +84,6 @@ daemon-4            : release_fn called as daemon callback for event=JOB ENDED
 daemon-4            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-4            : Application namespace @NS<1> terminated
 daemon-4            : Debugger daemon ns @NS<0> rank 4 pid @PID<4>: Finalizing
-daemon-4            : Debugger daemon ns @NS<0> rank 4 pid @PID<4>:PMIx_Finalize successfully completed
 daemon-5            : Debugger daemon ns @NS<0> on host @HOST<2> rank 5 pid @PID<5>: Running
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
 daemon-5            : [@NS<0>:-2:@PID<5>] PMIX_DEBUG_JOB is '@NS<1>'
@@ -106,7 +101,6 @@ daemon-5            : release_fn called as daemon callback for event=JOB ENDED
 daemon-5            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-5            : Application namespace @NS<1> terminated
 daemon-5            : Debugger daemon ns @NS<0> rank 5 pid @PID<5>: Finalizing
-daemon-5            : Debugger daemon ns @NS<0> rank 5 pid @PID<5>:PMIx_Finalize successfully completed
 direct-multi        : Debugger ns @NS<2> rank 0 pid @PID<6>: Running
 direct-multi        : evhandler_reg_callbk called to register callback
 direct-multi        : Called cbfunc as callback for PMIx_Query

--- a/prrte/debug/direct-multi.stdout.baseline
+++ b/prrte/debug/direct-multi.stdout.baseline
@@ -16,7 +16,6 @@ daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-0            : Application namespace @NS<1> terminated
 daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>:PMIx_Finalize successfully completed
 daemon-1            : Debugger daemon ns @NS<0> on host @HOST<1> rank 1 pid @PID<1>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : [@NS<0>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<1>'
@@ -34,7 +33,6 @@ daemon-1            : release_fn called as daemon callback for event=JOB ENDED
 daemon-1            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-1            : Application namespace @NS<1> terminated
 daemon-1            : Debugger daemon ns @NS<0> rank 1 pid @PID<1>: Finalizing
-daemon-1            : Debugger daemon ns @NS<0> rank 1 pid @PID<1>:PMIx_Finalize successfully completed
 daemon-2            : Debugger daemon ns @NS<0> on host @HOST<2> rank 2 pid @PID<2>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : [@NS<0>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<1>'
@@ -52,7 +50,6 @@ daemon-2            : release_fn called as daemon callback for event=JOB ENDED
 daemon-2            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-2            : Application namespace @NS<1> terminated
 daemon-2            : Debugger daemon ns @NS<0> rank 2 pid @PID<2>: Finalizing
-daemon-2            : Debugger daemon ns @NS<0> rank 2 pid @PID<2>:PMIx_Finalize successfully completed
 direct-multi        : Debugger ns @NS<2> rank 0 pid @PID<3>: Running
 direct-multi        : evhandler_reg_callbk called to register callback
 direct-multi        : Called cbfunc as callback for PMIx_Query

--- a/prrte/debug/direct.stdout.baseline
+++ b/prrte/debug/direct.stdout.baseline
@@ -16,7 +16,6 @@ daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-0            : Application namespace @NS<1> terminated
 daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>:PMIx_Finalize successfully completed
 direct              : Debugger ns @NS<2> rank 0 pid @PID<1>: Running
 direct              : Connected system server is @NS<3>:0
 direct              : evhandler_reg_callbk called to register callback

--- a/prrte/debug/indirect-colaunch1.stdout.baseline
+++ b/prrte/debug/indirect-colaunch1.stdout.baseline
@@ -18,7 +18,6 @@ daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-0            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 0 pid @PID<0>:PMIx_Finalize successfully completed
 daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 1 pid @PID<2>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<2>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -38,7 +37,6 @@ daemon-1            : release_fn called as daemon callback for event=JOB ENDED
 daemon-1            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-1            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 1 pid @PID<2>: Finalizing
-daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 1 pid @PID<2>:PMIx_Finalize successfully completed
 daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 2 pid @PID<3>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<3>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -58,7 +56,6 @@ daemon-2            : release_fn called as daemon callback for event=JOB ENDED
 daemon-2            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-2            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 2 pid @PID<3>: Finalizing
-daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 2 pid @PID<3>:PMIx_Finalize successfully completed
 hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0 pid @PID<4>: Running on host @HOST<0> localrank 0
 hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0: Finalizing
 hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0:PMIx_Finalize successfully completed

--- a/prrte/debug/indirect-colaunch1.stdout.baseline
+++ b/prrte/debug/indirect-colaunch1.stdout.baseline
@@ -99,15 +99,16 @@ indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Spawning launcher
 indirect-multi      : Launcher namespace is @NS<5>
 indirect-multi      : Reconnect to IL at @NS<5>
-indirect-multi      : Registering READY-FOR-DEBUG handler for @HOST<1>:@PID<1>:@NS<6>
+indirect-multi      : Registering READY-FOR-DEBUG handler
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
-indirect-multi      : Releasing prterun [@NS<7>]
+indirect-multi      : Releasing prterun [@NS<5>,0]
 indirect-multi      : Waiting for application launch
 indirect-multi      : Got READY-FOR-DEBUG event from nspace @HOST<1>:@PID<1>:@NS<6>
 indirect-multi      : Debugger daemon job: @HOST<1>:@PID<1>:@NS<2>
 indirect-multi      : Application has launched: @HOST<1>:@PID<1>:@NS<2>
 indirect-multi      : Debugger: spawning ./daemon
+indirect-multi      : Debugger nspace: @HOST<1>:@PID<1>:@NS<0>
+indirect-multi      : Registering handler for debugger termination
+indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Waiting for IL to terminate
 indirect-multi      : terminate_fn called with status LOST_CONNECTION
-indirect-multi      : Default event handler called with status LOST_CONNECTION
-indirect-multi      : 	Complete

--- a/prrte/debug/indirect-colaunch2.stdout.baseline
+++ b/prrte/debug/indirect-colaunch2.stdout.baseline
@@ -18,7 +18,6 @@ daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-0            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 0 pid @PID<0>:PMIx_Finalize successfully completed
 daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<0> rank 1 pid @PID<2>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<2>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -38,7 +37,6 @@ daemon-1            : release_fn called as daemon callback for event=JOB ENDED
 daemon-1            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-1            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 1 pid @PID<2>: Finalizing
-daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 1 pid @PID<2>:PMIx_Finalize successfully completed
 daemon-10           : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 10 pid @PID<3>: Running
 daemon-10           : evhandler_reg_callbk called by daemon as registration callback
 daemon-10           : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<3>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -58,7 +56,6 @@ daemon-10           : release_fn called as daemon callback for event=JOB ENDED
 daemon-10           : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-10           : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-10           : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 10 pid @PID<3>: Finalizing
-daemon-10           : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 10 pid @PID<3>:PMIx_Finalize successfully completed
 daemon-11           : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 11 pid @PID<4>: Running
 daemon-11           : evhandler_reg_callbk called by daemon as registration callback
 daemon-11           : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<4>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -78,7 +75,6 @@ daemon-11           : release_fn called as daemon callback for event=JOB ENDED
 daemon-11           : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-11           : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-11           : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 11 pid @PID<4>: Finalizing
-daemon-11           : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 11 pid @PID<4>:PMIx_Finalize successfully completed
 daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<0> rank 2 pid @PID<5>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<5>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -98,7 +94,6 @@ daemon-2            : release_fn called as daemon callback for event=JOB ENDED
 daemon-2            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-2            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 2 pid @PID<5>: Finalizing
-daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 2 pid @PID<5>:PMIx_Finalize successfully completed
 daemon-3            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<0> rank 3 pid @PID<6>: Running
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
 daemon-3            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<6>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -118,7 +113,6 @@ daemon-3            : release_fn called as daemon callback for event=JOB ENDED
 daemon-3            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-3            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-3            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 3 pid @PID<6>: Finalizing
-daemon-3            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 3 pid @PID<6>:PMIx_Finalize successfully completed
 daemon-4            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 4 pid @PID<7>: Running
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
 daemon-4            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<7>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -138,7 +132,6 @@ daemon-4            : release_fn called as daemon callback for event=JOB ENDED
 daemon-4            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-4            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-4            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 4 pid @PID<7>: Finalizing
-daemon-4            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 4 pid @PID<7>:PMIx_Finalize successfully completed
 daemon-5            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 5 pid @PID<8>: Running
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
 daemon-5            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<8>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -158,7 +151,6 @@ daemon-5            : release_fn called as daemon callback for event=JOB ENDED
 daemon-5            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-5            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-5            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 5 pid @PID<8>: Finalizing
-daemon-5            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 5 pid @PID<8>:PMIx_Finalize successfully completed
 daemon-6            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 6 pid @PID<9>: Running
 daemon-6            : evhandler_reg_callbk called by daemon as registration callback
 daemon-6            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<9>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -178,7 +170,6 @@ daemon-6            : release_fn called as daemon callback for event=JOB ENDED
 daemon-6            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-6            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-6            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 6 pid @PID<9>: Finalizing
-daemon-6            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 6 pid @PID<9>:PMIx_Finalize successfully completed
 daemon-7            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 7 pid @PID<10>: Running
 daemon-7            : evhandler_reg_callbk called by daemon as registration callback
 daemon-7            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<10>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -198,7 +189,6 @@ daemon-7            : release_fn called as daemon callback for event=JOB ENDED
 daemon-7            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-7            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-7            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 7 pid @PID<10>: Finalizing
-daemon-7            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 7 pid @PID<10>:PMIx_Finalize successfully completed
 daemon-8            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 8 pid @PID<11>: Running
 daemon-8            : evhandler_reg_callbk called by daemon as registration callback
 daemon-8            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<11>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -218,7 +208,6 @@ daemon-8            : release_fn called as daemon callback for event=JOB ENDED
 daemon-8            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-8            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-8            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 8 pid @PID<11>: Finalizing
-daemon-8            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 8 pid @PID<11>:PMIx_Finalize successfully completed
 daemon-9            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 9 pid @PID<12>: Running
 daemon-9            : evhandler_reg_callbk called by daemon as registration callback
 daemon-9            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<12>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -238,7 +227,6 @@ daemon-9            : release_fn called as daemon callback for event=JOB ENDED
 daemon-9            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-9            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-9            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 9 pid @PID<12>: Finalizing
-daemon-9            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 9 pid @PID<12>:PMIx_Finalize successfully completed
 hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0 pid @PID<13>: Running on host @HOST<0> localrank 0
 hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0: Finalizing
 hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0:PMIx_Finalize successfully completed

--- a/prrte/debug/indirect-colaunch2.stdout.baseline
+++ b/prrte/debug/indirect-colaunch2.stdout.baseline
@@ -270,15 +270,16 @@ indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Spawning launcher
 indirect-multi      : Launcher namespace is @NS<5>
 indirect-multi      : Reconnect to IL at @NS<5>
-indirect-multi      : Registering READY-FOR-DEBUG handler for @HOST<1>:@PID<1>:@NS<6>
+indirect-multi      : Registering READY-FOR-DEBUG handler
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
-indirect-multi      : Releasing prterun [@NS<7>]
+indirect-multi      : Releasing prterun [@NS<5>,0]
 indirect-multi      : Waiting for application launch
 indirect-multi      : Got READY-FOR-DEBUG event from nspace @HOST<1>:@PID<1>:@NS<6>
 indirect-multi      : Debugger daemon job: @HOST<1>:@PID<1>:@NS<2>
 indirect-multi      : Application has launched: @HOST<1>:@PID<1>:@NS<2>
 indirect-multi      : Debugger: spawning ./daemon
+indirect-multi      : Debugger nspace: @HOST<1>:@PID<1>:@NS<0>
+indirect-multi      : Registering handler for debugger termination
+indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Waiting for IL to terminate
 indirect-multi      : terminate_fn called with status LOST_CONNECTION
-indirect-multi      : Default event handler called with status LOST_CONNECTION
-indirect-multi      : 	Complete

--- a/prrte/debug/indirect-multi.stdout.baseline
+++ b/prrte/debug/indirect-multi.stdout.baseline
@@ -19,7 +19,6 @@ daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-0            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 0 pid @PID<0>:PMIx_Finalize successfully completed
 daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 1 pid @PID<2>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<2>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -40,7 +39,6 @@ daemon-1            : release_fn called as daemon callback for event=JOB ENDED
 daemon-1            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-1            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 1 pid @PID<2>: Finalizing
-daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 1 pid @PID<2>:PMIx_Finalize successfully completed
 daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 2 pid @PID<3>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<3>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
@@ -58,7 +56,6 @@ daemon-2            : release_fn called as daemon callback for event=JOB ENDED
 daemon-2            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
 daemon-2            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
 daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 2 pid @PID<3>: Finalizing
-daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 2 pid @PID<3>:PMIx_Finalize successfully completed
 hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0 pid @PID<4>: Running on host @HOST<0> localrank 0
 hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0: Finalizing
 hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0:PMIx_Finalize successfully completed

--- a/prrte/debug/indirect-multi.stdout.baseline
+++ b/prrte/debug/indirect-multi.stdout.baseline
@@ -99,15 +99,16 @@ indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Spawning launcher
 indirect-multi      : Launcher namespace is @NS<5>
 indirect-multi      : Reconnect to IL at @NS<5>
-indirect-multi      : Registering READY-FOR-DEBUG handler for @HOST<1>:@PID<1>:@NS<6>
+indirect-multi      : Registering READY-FOR-DEBUG handler
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
-indirect-multi      : Releasing prterun [@NS<7>]
+indirect-multi      : Releasing prterun [@NS<5>,0]
 indirect-multi      : Waiting for application launch
 indirect-multi      : Got READY-FOR-DEBUG event from nspace @HOST<1>:@PID<1>:@NS<6>
 indirect-multi      : Debugger daemon job: @HOST<1>:@PID<1>:@NS<2>
 indirect-multi      : Application has launched: @HOST<1>:@PID<1>:@NS<2>
 indirect-multi      : Debugger: spawning ./daemon
+indirect-multi      : Debugger nspace: @HOST<1>:@PID<1>:@NS<0>
+indirect-multi      : Registering handler for debugger termination
+indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Waiting for IL to terminate
 indirect-multi      : terminate_fn called with status LOST_CONNECTION
-indirect-multi      : Default event handler called with status LOST_CONNECTION
-indirect-multi      : 	Complete

--- a/prrte/debug/indirect-prterun.stdout.baseline
+++ b/prrte/debug/indirect-prterun.stdout.baseline
@@ -28,9 +28,9 @@ indirect            : evhandler_reg_callbk called with status SUCCESS
 indirect            : evhandler_reg_callbk called with status SUCCESS
 indirect            : SPAWNING LAUNCHER
 indirect            : RECONNECT TO IL AT @NS<5>
-indirect            : REGISTERING READY-FOR-DEBUG HANDLER for @HOST<0>:@PID<1>:@NS<6>
+indirect            : REGISTERING READY-FOR-DEBUG HANDLER
 indirect            : evhandler_reg_callbk called with status SUCCESS
-indirect            : RELEASING prterun [@NS<7>]
+indirect            : RELEASING prterun [@NS<5>,0]
 indirect            : WAITING FOR APPLICATION LAUNCH
 indirect            : GOT NSPACE @HOST<0>:@PID<1>:@NS<2>
 indirect            : Debugger daemon job: @HOST<0>:@PID<1>:@NS<2>
@@ -38,5 +38,3 @@ indirect            : APPLICATION HAS LAUNCHED: @HOST<0>:@PID<1>:@NS<2>
 indirect            : Debugger: spawning ./daemon
 indirect            : WAITING FOR IL TO TERMINATE
 indirect            : terminate_fn called with status LOST_CONNECTION
-indirect            : DEFAULT EVENT HANDLER CALLED WITH STATUS LOST_CONNECTION
-indirect            : 	COMPLETE

--- a/prrte/debug/indirect-prterun.stdout.baseline
+++ b/prrte/debug/indirect-prterun.stdout.baseline
@@ -16,7 +16,6 @@ daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @HOST<0>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<0>:@PID<1>:@NS<2>
 daemon-0            : Application namespace @HOST<0>:@PID<1>:@NS<2> terminated
 daemon-0            : Debugger daemon ns @HOST<0>:@PID<1>:@NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-0            : Debugger daemon ns @HOST<0>:@PID<1>:@NS<0> rank 0 pid @PID<0>:PMIx_Finalize successfully completed
 hello-0             : Client ns @HOST<0>:@PID<1>:@NS<2> rank 0 pid @PID<2>: Running on host @HOST<0> localrank 0
 hello-0             : Client ns @HOST<0>:@PID<1>:@NS<2> rank 0: Finalizing
 hello-0             : Client ns @HOST<0>:@PID<1>:@NS<2> rank 0:PMIx_Finalize successfully completed

--- a/prrte/debug/indirect-prun.stdout.baseline
+++ b/prrte/debug/indirect-prun.stdout.baseline
@@ -1,0 +1,42 @@
+daemon-0            : Debugger daemon ns @NS<0> on host @HOST<0> rank 0 pid @PID<0>: Running
+daemon-0            : evhandler_reg_callbk called by daemon as registration callback
+daemon-0            : [@NS<0>:-2:@PID<0>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-0            : [@NS<0>:0:@PID<0>] Debugging '@NS<1>'
+daemon-0            : [@NS<0>:0:@PID<0>] my local rank 0
+daemon-0            : [@NS<0>:0:@PID<0>] registering for termination of '@NS<1>'
+daemon-0            : evhandler_reg_callbk called by daemon as registration callback
+daemon-0            : cbfunc called as daemon callback for PMIx_Query
+daemon-0            : Transferring pmix.qry.lptable
+daemon-0            : [@NS<0>:0:@PID<0>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-0            : Proctable[0], namespace @NS<1> rank 0 exec hello
+daemon-0            : Proctable[1], namespace @NS<1> rank 1 exec hello
+daemon-0            : [@NS<0>:0:@PID<0>] Sending release
+daemon-0            : Waiting for application namespace @NS<1> to terminate
+daemon-0            : release_fn called as daemon callback for event=JOB ENDED
+daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
+daemon-0            : Application namespace @NS<1> terminated
+daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Finalizing
+hello-0             : Client ns @NS<1> rank 0 pid @PID<1>: Running on host @HOST<0> localrank 0
+hello-0             : Client ns @NS<1> rank 0: Finalizing
+hello-0             : Client ns @NS<1> rank 0:PMIx_Finalize successfully completed
+hello-1             : Client ns @NS<1> rank 1 pid @PID<2>: Running on host @HOST<0> localrank 1
+hello-1             : Client ns @NS<1> rank 1: Finalizing
+hello-1             : Client ns @NS<1> rank 1:PMIx_Finalize successfully completed
+indirect            : Debugger ns @NS<2> rank 0 pid @PID<3>: Running
+indirect            : DEBUGGER URI: @NS<3>;tcp4://@HOST<1>
+indirect            : evhandler_reg_callbk called with status SUCCESS
+indirect            : evhandler_reg_callbk called with status SUCCESS
+indirect            : SPAWNING LAUNCHER
+indirect            : RECONNECT TO IL AT @NS<4>
+indirect            : REGISTERING READY-FOR-DEBUG HANDLER for @HOST<0>:@PID<3>:@NS<5>
+indirect            : evhandler_reg_callbk called with status SUCCESS
+indirect            : RELEASING prun [@NS<6>]
+indirect            : WAITING FOR APPLICATION LAUNCH
+indirect            : GOT NSPACE @NS<1>
+indirect            : Debugger daemon job: @NS<1>
+indirect            : APPLICATION HAS LAUNCHED: @NS<1>
+indirect            : Debugger: spawning ./daemon
+indirect            : WAITING FOR IL TO TERMINATE
+indirect            : terminate_fn called with status LOST_CONNECTION from @NS<4>:0
+indirect            : DEFAULT EVENT HANDLER CALLED WITH STATUS LOST_CONNECTION
+indirect            : 	COMPLETE

--- a/prrte/debug/run.py
+++ b/prrte/debug/run.py
@@ -33,6 +33,11 @@ ATTACH_WAITTIME = 10.0
 #
 # A multinode testcase includes MULTINODE_TEST in it's testcase flags settings
 tests = [ ["direct", SYS_DAEMON_NEEDED, "./direct"],
+          ["attach", ATTACH_TARGET_NEEDED, "./attach", "$attach-namespace"],
+          ["indirect-prterun", 0, "./indirect", "prterun", "-n", "2",
+                  "./hello", "10"],
+          ["indirect-prun", SYS_DAEMON_NEEDED, "./indirect", "prun", "-n", "2",
+                  "./hello", "10"],
             # This test requires a hostfile with 3 slots per node
           ["direct-multi", SYS_DAEMON_NEEDED | MULTINODE_TEST, "./direct-multi",
                   "--app-pernode", "2", "--app-np", "6"],
@@ -51,7 +56,7 @@ tests = [ ["direct", SYS_DAEMON_NEEDED, "./direct"],
             # This test requires a hostfile with 4 slots per node
           ["indirect-colaunch1", MULTINODE_TEST, "./indirect-multi",
                   "--daemon-colocate-per-node", "1", "prterun", "--hostfile", "$hostfile",
-                  "--np", "12", "./hello"],
+                  "--np", "12", "./hello", "10"],
             # This test requires a hostfile with 4 slots per node
           ["indirect-colaunch2", MULTINODE_TEST, "./indirect-multi",
                   "--daemon-colocate-per-proc", "1", "prterun", "--hostfile", "$hostfile",
@@ -63,9 +68,6 @@ tests = [ ["direct", SYS_DAEMON_NEEDED, "./direct"],
           ["attach-colaunch2", ATTACH_TARGET_NEEDED | MULTINODE_TEST, "./attach",
                   "--daemon-colocate-per-proc", "1", "$attach-namespace"]
 # These testcases are not working at this point, so comment them out for now
-#         ["attach", ATTACH_TARGET_NEEDED, "./attach", "$attach-namespace"],
-#         ["indirect-prterun", 0, "./indirect", "prterun", "-n", "2",
-#                 "./hello", "10"],
         ]
 # Commands to start prte system daemons for multi-node tests. The testcase
 # name (array element 0) must match the name of the testcase in the tests array


### PR DESCRIPTION
Update baselines to match current PMIX debugger example testcases, where the main change is removing printfs following PMIX_tool_finailze since variations in timing and processing following the PMIX_tool_finalize call seems to make forwarding of stdio buffers inconsistent.

Update the set of testcases implemented by the run.py script

Signed-off-by: David Wootton <dwootton@us.ibm.com>