### PR TITLE
Modify tcfilter to replace hostnames and pids in testcase output with constant strings

### DIFF
--- a/prrte/debug/attach-colaunch1.stdout.baseline
+++ b/prrte/debug/attach-colaunch1.stdout.baseline
@@ -1,4 +1,4 @@
-attach              : Debugger ns @NS<0> rank 0 pid @PID<0>: Running
+attach              : Debugger ns @NS<0> rank 0 pid PID<?>: Running
 attach              : evhandler_reg_callbk called to register callback refid=0
 attach              : attach_to_running_job called to attach to application with namespace=@NS<1>
 attach              : query_application_namespace called to get application namespace
@@ -13,32 +13,32 @@ attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED - AFFECTED NU
 attach              : Debugger daemon namespace @NS<3> terminated
 attach              : Forwarded stdio data:
 attach              : End forwarded stdio
-daemon-0            : Debugger daemon ns @NS<3> on host @HOST<0> rank 0 pid @PID<1>: Running
-daemon-0            : Debugger daemon ns @NS<3> on host @HOST<0> rank 0 pid @PID<1>: Running
+daemon-0            : Debugger daemon ns @NS<3> on host <host> rank 0 pid PID<?>: Running
+daemon-0            : Debugger daemon ns @NS<3> on host <host> rank 0 pid PID<?>: Running
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
-daemon-0            : [@NS<3>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-0            : [@NS<3>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-0            : [@NS<3>:0:@PID<1>] Debugging '@NS<2>'
-daemon-0            : [@NS<3>:0:@PID<1>] Debugging '@NS<2>'
-daemon-0            : [@NS<3>:0:@PID<1>] my local rank 0
-daemon-0            : [@NS<3>:0:@PID<1>] my local rank 0
-daemon-0            : [@NS<3>:0:@PID<1>] registering for termination of '@NS<2>'
-daemon-0            : [@NS<3>:0:@PID<1>] registering for termination of '@NS<2>'
+daemon-0            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-0            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-0            : [@NS<3>:0:PID<?>] Debugging '@NS<2>'
+daemon-0            : [@NS<3>:0:PID<?>] Debugging '@NS<2>'
+daemon-0            : [@NS<3>:0:PID<?>] my local rank 0
+daemon-0            : [@NS<3>:0:PID<?>] my local rank 0
+daemon-0            : [@NS<3>:0:PID<?>] registering for termination of '@NS<2>'
+daemon-0            : [@NS<3>:0:PID<?>] registering for termination of '@NS<2>'
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : Transferring pmix.qry.lptable
 daemon-0            : Transferring pmix.qry.lptable
-daemon-0            : [@NS<3>:0:@PID<1>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-0            : [@NS<3>:0:@PID<1>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-0            : [@NS<3>:0:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-0            : [@NS<3>:0:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
 daemon-0            : Proctable[0], namespace @NS<2> rank 0 exec hello
 daemon-0            : Proctable[0], namespace @NS<2> rank 0 exec hello
 daemon-0            : Proctable[1], namespace @NS<2> rank 1 exec hello
 daemon-0            : Proctable[1], namespace @NS<2> rank 1 exec hello
-daemon-0            : [@NS<3>:0:@PID<1>] Sending release
-daemon-0            : [@NS<3>:0:@PID<1>] Sending release
+daemon-0            : [@NS<3>:0:PID<?>] Sending release
+daemon-0            : [@NS<3>:0:PID<?>] Sending release
 daemon-0            : Waiting for application namespace @NS<2> to terminate
 daemon-0            : Waiting for application namespace @NS<2> to terminate
 daemon-0            : release_fn called as daemon callback for event=JOB ENDED
@@ -47,28 +47,28 @@ daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINA
 daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
 daemon-0            : Application namespace @NS<2> terminated
 daemon-0            : Application namespace @NS<2> terminated
-daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
-daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
-daemon-1            : Debugger daemon ns @NS<3> on host @HOST<1> rank 1 pid @PID<2>: Running
-daemon-1            : Debugger daemon ns @NS<3> on host @HOST<1> rank 1 pid @PID<2>: Running
+daemon-0            : Debugger daemon ns @NS<3> rank 0 pid PID<?>: Finalizing
+daemon-0            : Debugger daemon ns @NS<3> rank 0 pid PID<?>: Finalizing
+daemon-1            : Debugger daemon ns @NS<3> on host <host> rank 1 pid PID<?>: Running
+daemon-1            : Debugger daemon ns @NS<3> on host <host> rank 1 pid PID<?>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
-daemon-1            : [@NS<3>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-1            : [@NS<3>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-1            : [@NS<3>:1:@PID<2>] Debugging '@NS<2>'
-daemon-1            : [@NS<3>:1:@PID<2>] Debugging '@NS<2>'
-daemon-1            : [@NS<3>:1:@PID<2>] my local rank 0
-daemon-1            : [@NS<3>:1:@PID<2>] my local rank 0
-daemon-1            : [@NS<3>:1:@PID<2>] registering for termination of '@NS<2>'
-daemon-1            : [@NS<3>:1:@PID<2>] registering for termination of '@NS<2>'
+daemon-1            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-1            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-1            : [@NS<3>:1:PID<?>] Debugging '@NS<2>'
+daemon-1            : [@NS<3>:1:PID<?>] Debugging '@NS<2>'
+daemon-1            : [@NS<3>:1:PID<?>] my local rank 0
+daemon-1            : [@NS<3>:1:PID<?>] my local rank 0
+daemon-1            : [@NS<3>:1:PID<?>] registering for termination of '@NS<2>'
+daemon-1            : [@NS<3>:1:PID<?>] registering for termination of '@NS<2>'
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : cbfunc called as daemon callback for PMIx_Query
 daemon-1            : cbfunc called as daemon callback for PMIx_Query
 daemon-1            : Transferring pmix.qry.lptable
 daemon-1            : Transferring pmix.qry.lptable
-daemon-1            : [@NS<3>:1:@PID<2>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-1            : [@NS<3>:1:@PID<2>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-1            : [@NS<3>:1:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-1            : [@NS<3>:1:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
 daemon-1            : Proctable[0], namespace @NS<2> rank 2 exec hello
 daemon-1            : Proctable[0], namespace @NS<2> rank 2 exec hello
 daemon-1            : Proctable[1], namespace @NS<2> rank 3 exec hello
@@ -81,28 +81,28 @@ daemon-1            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINA
 daemon-1            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
 daemon-1            : Application namespace @NS<2> terminated
 daemon-1            : Application namespace @NS<2> terminated
-daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>: Finalizing
-daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>: Finalizing
-daemon-2            : Debugger daemon ns @NS<3> on host @HOST<2> rank 2 pid @PID<3>: Running
-daemon-2            : Debugger daemon ns @NS<3> on host @HOST<2> rank 2 pid @PID<3>: Running
+daemon-1            : Debugger daemon ns @NS<3> rank 1 pid PID<?>: Finalizing
+daemon-1            : Debugger daemon ns @NS<3> rank 1 pid PID<?>: Finalizing
+daemon-2            : Debugger daemon ns @NS<3> on host <host> rank 2 pid PID<?>: Running
+daemon-2            : Debugger daemon ns @NS<3> on host <host> rank 2 pid PID<?>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
-daemon-2            : [@NS<3>:-2:@PID<3>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-2            : [@NS<3>:-2:@PID<3>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-2            : [@NS<3>:2:@PID<3>] Debugging '@NS<2>'
-daemon-2            : [@NS<3>:2:@PID<3>] Debugging '@NS<2>'
-daemon-2            : [@NS<3>:2:@PID<3>] my local rank 0
-daemon-2            : [@NS<3>:2:@PID<3>] my local rank 0
-daemon-2            : [@NS<3>:2:@PID<3>] registering for termination of '@NS<2>'
-daemon-2            : [@NS<3>:2:@PID<3>] registering for termination of '@NS<2>'
+daemon-2            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-2            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-2            : [@NS<3>:2:PID<?>] Debugging '@NS<2>'
+daemon-2            : [@NS<3>:2:PID<?>] Debugging '@NS<2>'
+daemon-2            : [@NS<3>:2:PID<?>] my local rank 0
+daemon-2            : [@NS<3>:2:PID<?>] my local rank 0
+daemon-2            : [@NS<3>:2:PID<?>] registering for termination of '@NS<2>'
+daemon-2            : [@NS<3>:2:PID<?>] registering for termination of '@NS<2>'
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : cbfunc called as daemon callback for PMIx_Query
 daemon-2            : cbfunc called as daemon callback for PMIx_Query
 daemon-2            : Transferring pmix.qry.lptable
 daemon-2            : Transferring pmix.qry.lptable
-daemon-2            : [@NS<3>:2:@PID<3>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-2            : [@NS<3>:2:@PID<3>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-2            : [@NS<3>:2:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-2            : [@NS<3>:2:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
 daemon-2            : Proctable[0], namespace @NS<2> rank 4 exec hello
 daemon-2            : Proctable[0], namespace @NS<2> rank 4 exec hello
 daemon-2            : Proctable[1], namespace @NS<2> rank 5 exec hello
@@ -115,5 +115,5 @@ daemon-2            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINA
 daemon-2            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
 daemon-2            : Application namespace @NS<2> terminated
 daemon-2            : Application namespace @NS<2> terminated
-daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>: Finalizing
-daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>: Finalizing
+daemon-2            : Debugger daemon ns @NS<3> rank 2 pid PID<?>: Finalizing
+daemon-2            : Debugger daemon ns @NS<3> rank 2 pid PID<?>: Finalizing

--- a/prrte/debug/attach-colaunch2.stdout.baseline
+++ b/prrte/debug/attach-colaunch2.stdout.baseline
@@ -1,4 +1,4 @@
-attach              : Debugger ns @NS<0> rank 0 pid @PID<0>: Running
+attach              : Debugger ns @NS<0> rank 0 pid PID<?>: Running
 attach              : evhandler_reg_callbk called to register callback refid=0
 attach              : attach_to_running_job called to attach to application with namespace=@NS<1>
 attach              : query_application_namespace called to get application namespace
@@ -13,32 +13,32 @@ attach              : DEBUGGER NOTIFIED THAT JOB @NS<3> TERMINATED - AFFECTED NU
 attach              : Debugger daemon namespace @NS<3> terminated
 attach              : Forwarded stdio data:
 attach              : End forwarded stdio
-daemon-0            : Debugger daemon ns @NS<3> on host @HOST<0> rank 0 pid @PID<1>: Running
-daemon-0            : Debugger daemon ns @NS<3> on host @HOST<0> rank 0 pid @PID<1>: Running
+daemon-0            : Debugger daemon ns @NS<3> on host <host> rank 0 pid PID<?>: Running
+daemon-0            : Debugger daemon ns @NS<3> on host <host> rank 0 pid PID<?>: Running
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
-daemon-0            : [@NS<3>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-0            : [@NS<3>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-0            : [@NS<3>:0:@PID<1>] Debugging '@NS<2>'
-daemon-0            : [@NS<3>:0:@PID<1>] Debugging '@NS<2>'
-daemon-0            : [@NS<3>:0:@PID<1>] my local rank 0
-daemon-0            : [@NS<3>:0:@PID<1>] my local rank 0
-daemon-0            : [@NS<3>:0:@PID<1>] registering for termination of '@NS<2>'
-daemon-0            : [@NS<3>:0:@PID<1>] registering for termination of '@NS<2>'
+daemon-0            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-0            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-0            : [@NS<3>:0:PID<?>] Debugging '@NS<2>'
+daemon-0            : [@NS<3>:0:PID<?>] Debugging '@NS<2>'
+daemon-0            : [@NS<3>:0:PID<?>] my local rank 0
+daemon-0            : [@NS<3>:0:PID<?>] my local rank 0
+daemon-0            : [@NS<3>:0:PID<?>] registering for termination of '@NS<2>'
+daemon-0            : [@NS<3>:0:PID<?>] registering for termination of '@NS<2>'
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : Transferring pmix.qry.lptable
 daemon-0            : Transferring pmix.qry.lptable
-daemon-0            : [@NS<3>:0:@PID<1>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-0            : [@NS<3>:0:@PID<1>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-0            : [@NS<3>:0:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-0            : [@NS<3>:0:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
 daemon-0            : Proctable[0], namespace @NS<2> rank 0 exec hello
 daemon-0            : Proctable[0], namespace @NS<2> rank 0 exec hello
 daemon-0            : Proctable[1], namespace @NS<2> rank 1 exec hello
 daemon-0            : Proctable[1], namespace @NS<2> rank 1 exec hello
-daemon-0            : [@NS<3>:0:@PID<1>] Sending release
-daemon-0            : [@NS<3>:0:@PID<1>] Sending release
+daemon-0            : [@NS<3>:0:PID<?>] Sending release
+daemon-0            : [@NS<3>:0:PID<?>] Sending release
 daemon-0            : Waiting for application namespace @NS<2> to terminate
 daemon-0            : Waiting for application namespace @NS<2> to terminate
 daemon-0            : release_fn called as daemon callback for event=JOB ENDED
@@ -47,28 +47,28 @@ daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINA
 daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
 daemon-0            : Application namespace @NS<2> terminated
 daemon-0            : Application namespace @NS<2> terminated
-daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
-daemon-0            : Debugger daemon ns @NS<3> rank 0 pid @PID<1>: Finalizing
-daemon-1            : Debugger daemon ns @NS<3> on host @HOST<0> rank 1 pid @PID<2>: Running
-daemon-1            : Debugger daemon ns @NS<3> on host @HOST<0> rank 1 pid @PID<2>: Running
+daemon-0            : Debugger daemon ns @NS<3> rank 0 pid PID<?>: Finalizing
+daemon-0            : Debugger daemon ns @NS<3> rank 0 pid PID<?>: Finalizing
+daemon-1            : Debugger daemon ns @NS<3> on host <host> rank 1 pid PID<?>: Running
+daemon-1            : Debugger daemon ns @NS<3> on host <host> rank 1 pid PID<?>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
-daemon-1            : [@NS<3>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-1            : [@NS<3>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-1            : [@NS<3>:1:@PID<2>] Debugging '@NS<2>'
-daemon-1            : [@NS<3>:1:@PID<2>] Debugging '@NS<2>'
-daemon-1            : [@NS<3>:1:@PID<2>] my local rank 1
-daemon-1            : [@NS<3>:1:@PID<2>] my local rank 1
-daemon-1            : [@NS<3>:1:@PID<2>] registering for termination of '@NS<2>'
-daemon-1            : [@NS<3>:1:@PID<2>] registering for termination of '@NS<2>'
+daemon-1            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-1            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-1            : [@NS<3>:1:PID<?>] Debugging '@NS<2>'
+daemon-1            : [@NS<3>:1:PID<?>] Debugging '@NS<2>'
+daemon-1            : [@NS<3>:1:PID<?>] my local rank 1
+daemon-1            : [@NS<3>:1:PID<?>] my local rank 1
+daemon-1            : [@NS<3>:1:PID<?>] registering for termination of '@NS<2>'
+daemon-1            : [@NS<3>:1:PID<?>] registering for termination of '@NS<2>'
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : cbfunc called as daemon callback for PMIx_Query
 daemon-1            : cbfunc called as daemon callback for PMIx_Query
 daemon-1            : Transferring pmix.qry.lptable
 daemon-1            : Transferring pmix.qry.lptable
-daemon-1            : [@NS<3>:1:@PID<2>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-1            : [@NS<3>:1:@PID<2>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-1            : [@NS<3>:1:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-1            : [@NS<3>:1:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
 daemon-1            : Proctable[0], namespace @NS<2> rank 0 exec hello
 daemon-1            : Proctable[0], namespace @NS<2> rank 0 exec hello
 daemon-1            : Proctable[1], namespace @NS<2> rank 1 exec hello
@@ -81,28 +81,28 @@ daemon-1            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINA
 daemon-1            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
 daemon-1            : Application namespace @NS<2> terminated
 daemon-1            : Application namespace @NS<2> terminated
-daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>: Finalizing
-daemon-1            : Debugger daemon ns @NS<3> rank 1 pid @PID<2>: Finalizing
-daemon-2            : Debugger daemon ns @NS<3> on host @HOST<1> rank 2 pid @PID<3>: Running
-daemon-2            : Debugger daemon ns @NS<3> on host @HOST<1> rank 2 pid @PID<3>: Running
+daemon-1            : Debugger daemon ns @NS<3> rank 1 pid PID<?>: Finalizing
+daemon-1            : Debugger daemon ns @NS<3> rank 1 pid PID<?>: Finalizing
+daemon-2            : Debugger daemon ns @NS<3> on host <host> rank 2 pid PID<?>: Running
+daemon-2            : Debugger daemon ns @NS<3> on host <host> rank 2 pid PID<?>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
-daemon-2            : [@NS<3>:-2:@PID<3>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-2            : [@NS<3>:-2:@PID<3>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-2            : [@NS<3>:2:@PID<3>] Debugging '@NS<2>'
-daemon-2            : [@NS<3>:2:@PID<3>] Debugging '@NS<2>'
-daemon-2            : [@NS<3>:2:@PID<3>] my local rank 0
-daemon-2            : [@NS<3>:2:@PID<3>] my local rank 0
-daemon-2            : [@NS<3>:2:@PID<3>] registering for termination of '@NS<2>'
-daemon-2            : [@NS<3>:2:@PID<3>] registering for termination of '@NS<2>'
+daemon-2            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-2            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-2            : [@NS<3>:2:PID<?>] Debugging '@NS<2>'
+daemon-2            : [@NS<3>:2:PID<?>] Debugging '@NS<2>'
+daemon-2            : [@NS<3>:2:PID<?>] my local rank 0
+daemon-2            : [@NS<3>:2:PID<?>] my local rank 0
+daemon-2            : [@NS<3>:2:PID<?>] registering for termination of '@NS<2>'
+daemon-2            : [@NS<3>:2:PID<?>] registering for termination of '@NS<2>'
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : cbfunc called as daemon callback for PMIx_Query
 daemon-2            : cbfunc called as daemon callback for PMIx_Query
 daemon-2            : Transferring pmix.qry.lptable
 daemon-2            : Transferring pmix.qry.lptable
-daemon-2            : [@NS<3>:2:@PID<3>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-2            : [@NS<3>:2:@PID<3>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-2            : [@NS<3>:2:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-2            : [@NS<3>:2:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
 daemon-2            : Proctable[0], namespace @NS<2> rank 2 exec hello
 daemon-2            : Proctable[0], namespace @NS<2> rank 2 exec hello
 daemon-2            : Proctable[1], namespace @NS<2> rank 3 exec hello
@@ -115,28 +115,28 @@ daemon-2            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINA
 daemon-2            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
 daemon-2            : Application namespace @NS<2> terminated
 daemon-2            : Application namespace @NS<2> terminated
-daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>: Finalizing
-daemon-2            : Debugger daemon ns @NS<3> rank 2 pid @PID<3>: Finalizing
-daemon-3            : Debugger daemon ns @NS<3> on host @HOST<1> rank 3 pid @PID<4>: Running
-daemon-3            : Debugger daemon ns @NS<3> on host @HOST<1> rank 3 pid @PID<4>: Running
+daemon-2            : Debugger daemon ns @NS<3> rank 2 pid PID<?>: Finalizing
+daemon-2            : Debugger daemon ns @NS<3> rank 2 pid PID<?>: Finalizing
+daemon-3            : Debugger daemon ns @NS<3> on host <host> rank 3 pid PID<?>: Running
+daemon-3            : Debugger daemon ns @NS<3> on host <host> rank 3 pid PID<?>: Running
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
-daemon-3            : [@NS<3>:-2:@PID<4>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-3            : [@NS<3>:-2:@PID<4>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-3            : [@NS<3>:3:@PID<4>] Debugging '@NS<2>'
-daemon-3            : [@NS<3>:3:@PID<4>] Debugging '@NS<2>'
-daemon-3            : [@NS<3>:3:@PID<4>] my local rank 1
-daemon-3            : [@NS<3>:3:@PID<4>] my local rank 1
-daemon-3            : [@NS<3>:3:@PID<4>] registering for termination of '@NS<2>'
-daemon-3            : [@NS<3>:3:@PID<4>] registering for termination of '@NS<2>'
+daemon-3            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-3            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-3            : [@NS<3>:3:PID<?>] Debugging '@NS<2>'
+daemon-3            : [@NS<3>:3:PID<?>] Debugging '@NS<2>'
+daemon-3            : [@NS<3>:3:PID<?>] my local rank 1
+daemon-3            : [@NS<3>:3:PID<?>] my local rank 1
+daemon-3            : [@NS<3>:3:PID<?>] registering for termination of '@NS<2>'
+daemon-3            : [@NS<3>:3:PID<?>] registering for termination of '@NS<2>'
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
 daemon-3            : cbfunc called as daemon callback for PMIx_Query
 daemon-3            : cbfunc called as daemon callback for PMIx_Query
 daemon-3            : Transferring pmix.qry.lptable
 daemon-3            : Transferring pmix.qry.lptable
-daemon-3            : [@NS<3>:3:@PID<4>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-3            : [@NS<3>:3:@PID<4>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-3            : [@NS<3>:3:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-3            : [@NS<3>:3:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
 daemon-3            : Proctable[0], namespace @NS<2> rank 2 exec hello
 daemon-3            : Proctable[0], namespace @NS<2> rank 2 exec hello
 daemon-3            : Proctable[1], namespace @NS<2> rank 3 exec hello
@@ -149,28 +149,28 @@ daemon-3            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINA
 daemon-3            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
 daemon-3            : Application namespace @NS<2> terminated
 daemon-3            : Application namespace @NS<2> terminated
-daemon-3            : Debugger daemon ns @NS<3> rank 3 pid @PID<4>: Finalizing
-daemon-3            : Debugger daemon ns @NS<3> rank 3 pid @PID<4>: Finalizing
-daemon-4            : Debugger daemon ns @NS<3> on host @HOST<2> rank 4 pid @PID<5>: Running
-daemon-4            : Debugger daemon ns @NS<3> on host @HOST<2> rank 4 pid @PID<5>: Running
+daemon-3            : Debugger daemon ns @NS<3> rank 3 pid PID<?>: Finalizing
+daemon-3            : Debugger daemon ns @NS<3> rank 3 pid PID<?>: Finalizing
+daemon-4            : Debugger daemon ns @NS<3> on host <host> rank 4 pid PID<?>: Running
+daemon-4            : Debugger daemon ns @NS<3> on host <host> rank 4 pid PID<?>: Running
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
-daemon-4            : [@NS<3>:-2:@PID<5>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-4            : [@NS<3>:-2:@PID<5>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-4            : [@NS<3>:4:@PID<5>] Debugging '@NS<2>'
-daemon-4            : [@NS<3>:4:@PID<5>] Debugging '@NS<2>'
-daemon-4            : [@NS<3>:4:@PID<5>] my local rank 0
-daemon-4            : [@NS<3>:4:@PID<5>] my local rank 0
-daemon-4            : [@NS<3>:4:@PID<5>] registering for termination of '@NS<2>'
-daemon-4            : [@NS<3>:4:@PID<5>] registering for termination of '@NS<2>'
+daemon-4            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-4            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-4            : [@NS<3>:4:PID<?>] Debugging '@NS<2>'
+daemon-4            : [@NS<3>:4:PID<?>] Debugging '@NS<2>'
+daemon-4            : [@NS<3>:4:PID<?>] my local rank 0
+daemon-4            : [@NS<3>:4:PID<?>] my local rank 0
+daemon-4            : [@NS<3>:4:PID<?>] registering for termination of '@NS<2>'
+daemon-4            : [@NS<3>:4:PID<?>] registering for termination of '@NS<2>'
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
 daemon-4            : cbfunc called as daemon callback for PMIx_Query
 daemon-4            : cbfunc called as daemon callback for PMIx_Query
 daemon-4            : Transferring pmix.qry.lptable
 daemon-4            : Transferring pmix.qry.lptable
-daemon-4            : [@NS<3>:4:@PID<5>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-4            : [@NS<3>:4:@PID<5>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-4            : [@NS<3>:4:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-4            : [@NS<3>:4:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
 daemon-4            : Proctable[0], namespace @NS<2> rank 4 exec hello
 daemon-4            : Proctable[0], namespace @NS<2> rank 4 exec hello
 daemon-4            : Proctable[1], namespace @NS<2> rank 5 exec hello
@@ -183,28 +183,28 @@ daemon-4            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINA
 daemon-4            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
 daemon-4            : Application namespace @NS<2> terminated
 daemon-4            : Application namespace @NS<2> terminated
-daemon-4            : Debugger daemon ns @NS<3> rank 4 pid @PID<5>: Finalizing
-daemon-4            : Debugger daemon ns @NS<3> rank 4 pid @PID<5>: Finalizing
-daemon-5            : Debugger daemon ns @NS<3> on host @HOST<2> rank 5 pid @PID<6>: Running
-daemon-5            : Debugger daemon ns @NS<3> on host @HOST<2> rank 5 pid @PID<6>: Running
+daemon-4            : Debugger daemon ns @NS<3> rank 4 pid PID<?>: Finalizing
+daemon-4            : Debugger daemon ns @NS<3> rank 4 pid PID<?>: Finalizing
+daemon-5            : Debugger daemon ns @NS<3> on host <host> rank 5 pid PID<?>: Running
+daemon-5            : Debugger daemon ns @NS<3> on host <host> rank 5 pid PID<?>: Running
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
-daemon-5            : [@NS<3>:-2:@PID<6>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-5            : [@NS<3>:-2:@PID<6>] PMIX_DEBUG_JOB is '@NS<2>'
-daemon-5            : [@NS<3>:5:@PID<6>] Debugging '@NS<2>'
-daemon-5            : [@NS<3>:5:@PID<6>] Debugging '@NS<2>'
-daemon-5            : [@NS<3>:5:@PID<6>] my local rank 1
-daemon-5            : [@NS<3>:5:@PID<6>] my local rank 1
-daemon-5            : [@NS<3>:5:@PID<6>] registering for termination of '@NS<2>'
-daemon-5            : [@NS<3>:5:@PID<6>] registering for termination of '@NS<2>'
+daemon-5            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-5            : [@NS<3>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<2>'
+daemon-5            : [@NS<3>:5:PID<?>] Debugging '@NS<2>'
+daemon-5            : [@NS<3>:5:PID<?>] Debugging '@NS<2>'
+daemon-5            : [@NS<3>:5:PID<?>] my local rank 1
+daemon-5            : [@NS<3>:5:PID<?>] my local rank 1
+daemon-5            : [@NS<3>:5:PID<?>] registering for termination of '@NS<2>'
+daemon-5            : [@NS<3>:5:PID<?>] registering for termination of '@NS<2>'
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
 daemon-5            : cbfunc called as daemon callback for PMIx_Query
 daemon-5            : cbfunc called as daemon callback for PMIx_Query
 daemon-5            : Transferring pmix.qry.lptable
 daemon-5            : Transferring pmix.qry.lptable
-daemon-5            : [@NS<3>:5:@PID<6>] Local proctable received for nspace '@NS<2>' has 2 entries
-daemon-5            : [@NS<3>:5:@PID<6>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-5            : [@NS<3>:5:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
+daemon-5            : [@NS<3>:5:PID<?>] Local proctable received for nspace '@NS<2>' has 2 entries
 daemon-5            : Proctable[0], namespace @NS<2> rank 4 exec hello
 daemon-5            : Proctable[0], namespace @NS<2> rank 4 exec hello
 daemon-5            : Proctable[1], namespace @NS<2> rank 5 exec hello
@@ -217,5 +217,5 @@ daemon-5            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINA
 daemon-5            : DEBUGGER DAEMON NAMESPACE @NS<3> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<2>
 daemon-5            : Application namespace @NS<2> terminated
 daemon-5            : Application namespace @NS<2> terminated
-daemon-5            : Debugger daemon ns @NS<3> rank 5 pid @PID<6>: Finalizing
-daemon-5            : Debugger daemon ns @NS<3> rank 5 pid @PID<6>: Finalizing
+daemon-5            : Debugger daemon ns @NS<3> rank 5 pid PID<?>: Finalizing
+daemon-5            : Debugger daemon ns @NS<3> rank 5 pid PID<?>: Finalizing

--- a/prrte/debug/direct-colaunch1.stdout.baseline
+++ b/prrte/debug/direct-colaunch1.stdout.baseline
@@ -1,56 +1,56 @@
-daemon-0            : Debugger daemon ns @NS<0> on host @HOST<0> rank 0 pid @PID<0>: Running
+daemon-0            : Debugger daemon ns @NS<0> on host <host> rank 0 pid PID<?>: Running
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
-daemon-0            : [@NS<0>:-2:@PID<0>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-0            : [@NS<0>:0:@PID<0>] Debugging '@NS<1>'
-daemon-0            : [@NS<0>:0:@PID<0>] my local rank 0
-daemon-0            : [@NS<0>:0:@PID<0>] registering for termination of '@NS<1>'
+daemon-0            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-0            : [@NS<0>:0:PID<?>] Debugging '@NS<1>'
+daemon-0            : [@NS<0>:0:PID<?>] my local rank 0
+daemon-0            : [@NS<0>:0:PID<?>] registering for termination of '@NS<1>'
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : Transferring pmix.qry.lptable
-daemon-0            : [@NS<0>:0:@PID<0>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-0            : [@NS<0>:0:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-0            : Proctable[0], namespace @NS<1> rank 0 exec hello
 daemon-0            : Proctable[1], namespace @NS<1> rank 1 exec hello
-daemon-0            : [@NS<0>:0:@PID<0>] Sending release
+daemon-0            : [@NS<0>:0:PID<?>] Sending release
 daemon-0            : Waiting for application namespace @NS<1> to terminate
 daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-0            : Application namespace @NS<1> terminated
-daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-1            : Debugger daemon ns @NS<0> on host @HOST<1> rank 1 pid @PID<1>: Running
+daemon-0            : Debugger daemon ns @NS<0> rank 0 pid PID<?>: Finalizing
+daemon-1            : Debugger daemon ns @NS<0> on host <host> rank 1 pid PID<?>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
-daemon-1            : [@NS<0>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-1            : [@NS<0>:1:@PID<1>] Debugging '@NS<1>'
-daemon-1            : [@NS<0>:1:@PID<1>] my local rank 0
-daemon-1            : [@NS<0>:1:@PID<1>] registering for termination of '@NS<1>'
+daemon-1            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-1            : [@NS<0>:1:PID<?>] Debugging '@NS<1>'
+daemon-1            : [@NS<0>:1:PID<?>] my local rank 0
+daemon-1            : [@NS<0>:1:PID<?>] registering for termination of '@NS<1>'
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : cbfunc called as daemon callback for PMIx_Query
 daemon-1            : Transferring pmix.qry.lptable
-daemon-1            : [@NS<0>:1:@PID<1>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-1            : [@NS<0>:1:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-1            : Proctable[0], namespace @NS<1> rank 2 exec hello
 daemon-1            : Proctable[1], namespace @NS<1> rank 3 exec hello
 daemon-1            : Waiting for application namespace @NS<1> to terminate
 daemon-1            : release_fn called as daemon callback for event=JOB ENDED
 daemon-1            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-1            : Application namespace @NS<1> terminated
-daemon-1            : Debugger daemon ns @NS<0> rank 1 pid @PID<1>: Finalizing
-daemon-2            : Debugger daemon ns @NS<0> on host @HOST<2> rank 2 pid @PID<2>: Running
+daemon-1            : Debugger daemon ns @NS<0> rank 1 pid PID<?>: Finalizing
+daemon-2            : Debugger daemon ns @NS<0> on host <host> rank 2 pid PID<?>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
-daemon-2            : [@NS<0>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-2            : [@NS<0>:2:@PID<2>] Debugging '@NS<1>'
-daemon-2            : [@NS<0>:2:@PID<2>] my local rank 0
-daemon-2            : [@NS<0>:2:@PID<2>] registering for termination of '@NS<1>'
+daemon-2            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-2            : [@NS<0>:2:PID<?>] Debugging '@NS<1>'
+daemon-2            : [@NS<0>:2:PID<?>] my local rank 0
+daemon-2            : [@NS<0>:2:PID<?>] registering for termination of '@NS<1>'
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : cbfunc called as daemon callback for PMIx_Query
 daemon-2            : Transferring pmix.qry.lptable
-daemon-2            : [@NS<0>:2:@PID<2>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-2            : [@NS<0>:2:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-2            : Proctable[0], namespace @NS<1> rank 4 exec hello
 daemon-2            : Proctable[1], namespace @NS<1> rank 5 exec hello
 daemon-2            : Waiting for application namespace @NS<1> to terminate
 daemon-2            : release_fn called as daemon callback for event=JOB ENDED
 daemon-2            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-2            : Application namespace @NS<1> terminated
-daemon-2            : Debugger daemon ns @NS<0> rank 2 pid @PID<2>: Finalizing
-direct-multi        : Debugger ns @NS<2> rank 0 pid @PID<3>: Running
+daemon-2            : Debugger daemon ns @NS<0> rank 2 pid PID<?>: Finalizing
+direct-multi        : Debugger ns @NS<2> rank 0 pid PID<?>: Running
 direct-multi        : evhandler_reg_callbk called to register callback
 direct-multi        : Called cbfunc as callback for PMIx_Query
 direct-multi        : Key pmix.qry.spawn Type PMIX_STRING(3)
@@ -72,21 +72,21 @@ direct-multi        : release_fn called as callback for event=JOB ENDED source=@
 direct-multi        : DEBUGGER NOTIFIED THAT JOB @NS<1> TERMINATED 
 direct-multi        : release_fn called as callback for event=JOB ENDED source=@NS<0>:0
 direct-multi        : DEBUGGER NOTIFIED THAT JOB @NS<0> TERMINATED 
-hello-0             : Client ns @NS<1> rank 0 pid @PID<4>: Running on host @HOST<0> localrank 0
+hello-0             : Client ns @NS<1> rank 0 pid PID<?>: Running on host <host> localrank 0
 hello-0             : Client ns @NS<1> rank 0: Finalizing
 hello-0             : Client ns @NS<1> rank 0:PMIx_Finalize successfully completed
-hello-1             : Client ns @NS<1> rank 1 pid @PID<5>: Running on host @HOST<0> localrank 1
+hello-1             : Client ns @NS<1> rank 1 pid PID<?>: Running on host <host> localrank 1
 hello-1             : Client ns @NS<1> rank 1: Finalizing
 hello-1             : Client ns @NS<1> rank 1:PMIx_Finalize successfully completed
-hello-2             : Client ns @NS<1> rank 2 pid @PID<6>: Running on host @HOST<1> localrank 0
+hello-2             : Client ns @NS<1> rank 2 pid PID<?>: Running on host <host> localrank 0
 hello-2             : Client ns @NS<1> rank 2: Finalizing
 hello-2             : Client ns @NS<1> rank 2:PMIx_Finalize successfully completed
-hello-3             : Client ns @NS<1> rank 3 pid @PID<7>: Running on host @HOST<1> localrank 1
+hello-3             : Client ns @NS<1> rank 3 pid PID<?>: Running on host <host> localrank 1
 hello-3             : Client ns @NS<1> rank 3: Finalizing
 hello-3             : Client ns @NS<1> rank 3:PMIx_Finalize successfully completed
-hello-4             : Client ns @NS<1> rank 4 pid @PID<8>: Running on host @HOST<2> localrank 0
+hello-4             : Client ns @NS<1> rank 4 pid PID<?>: Running on host <host> localrank 0
 hello-4             : Client ns @NS<1> rank 4: Finalizing
 hello-4             : Client ns @NS<1> rank 4:PMIx_Finalize successfully completed
-hello-5             : Client ns @NS<1> rank 5 pid @PID<9>: Running on host @HOST<2> localrank 1
+hello-5             : Client ns @NS<1> rank 5 pid PID<?>: Running on host <host> localrank 1
 hello-5             : Client ns @NS<1> rank 5: Finalizing
 hello-5             : Client ns @NS<1> rank 5:PMIx_Finalize successfully completed

--- a/prrte/debug/direct-colaunch2.stdout.baseline
+++ b/prrte/debug/direct-colaunch2.stdout.baseline
@@ -1,107 +1,107 @@
-daemon-0            : Debugger daemon ns @NS<0> on host @HOST<0> rank 0 pid @PID<0>: Running
+daemon-0            : Debugger daemon ns @NS<0> on host <host> rank 0 pid PID<?>: Running
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
-daemon-0            : [@NS<0>:-2:@PID<0>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-0            : [@NS<0>:0:@PID<0>] Debugging '@NS<1>'
-daemon-0            : [@NS<0>:0:@PID<0>] my local rank 0
-daemon-0            : [@NS<0>:0:@PID<0>] registering for termination of '@NS<1>'
+daemon-0            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-0            : [@NS<0>:0:PID<?>] Debugging '@NS<1>'
+daemon-0            : [@NS<0>:0:PID<?>] my local rank 0
+daemon-0            : [@NS<0>:0:PID<?>] registering for termination of '@NS<1>'
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : Transferring pmix.qry.lptable
-daemon-0            : [@NS<0>:0:@PID<0>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-0            : [@NS<0>:0:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-0            : Proctable[0], namespace @NS<1> rank 0 exec hello
 daemon-0            : Proctable[1], namespace @NS<1> rank 1 exec hello
-daemon-0            : [@NS<0>:0:@PID<0>] Sending release
+daemon-0            : [@NS<0>:0:PID<?>] Sending release
 daemon-0            : Waiting for application namespace @NS<1> to terminate
 daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-0            : Application namespace @NS<1> terminated
-daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-1            : Debugger daemon ns @NS<0> on host @HOST<0> rank 1 pid @PID<1>: Running
+daemon-0            : Debugger daemon ns @NS<0> rank 0 pid PID<?>: Finalizing
+daemon-1            : Debugger daemon ns @NS<0> on host <host> rank 1 pid PID<?>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
-daemon-1            : [@NS<0>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-1            : [@NS<0>:1:@PID<1>] Debugging '@NS<1>'
-daemon-1            : [@NS<0>:1:@PID<1>] my local rank 1
-daemon-1            : [@NS<0>:1:@PID<1>] registering for termination of '@NS<1>'
+daemon-1            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-1            : [@NS<0>:1:PID<?>] Debugging '@NS<1>'
+daemon-1            : [@NS<0>:1:PID<?>] my local rank 1
+daemon-1            : [@NS<0>:1:PID<?>] registering for termination of '@NS<1>'
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : cbfunc called as daemon callback for PMIx_Query
 daemon-1            : Transferring pmix.qry.lptable
-daemon-1            : [@NS<0>:1:@PID<1>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-1            : [@NS<0>:1:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-1            : Proctable[0], namespace @NS<1> rank 0 exec hello
 daemon-1            : Proctable[1], namespace @NS<1> rank 1 exec hello
 daemon-1            : Waiting for application namespace @NS<1> to terminate
 daemon-1            : release_fn called as daemon callback for event=JOB ENDED
 daemon-1            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-1            : Application namespace @NS<1> terminated
-daemon-1            : Debugger daemon ns @NS<0> rank 1 pid @PID<1>: Finalizing
-daemon-2            : Debugger daemon ns @NS<0> on host @HOST<1> rank 2 pid @PID<2>: Running
+daemon-1            : Debugger daemon ns @NS<0> rank 1 pid PID<?>: Finalizing
+daemon-2            : Debugger daemon ns @NS<0> on host <host> rank 2 pid PID<?>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
-daemon-2            : [@NS<0>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-2            : [@NS<0>:2:@PID<2>] Debugging '@NS<1>'
-daemon-2            : [@NS<0>:2:@PID<2>] my local rank 0
-daemon-2            : [@NS<0>:2:@PID<2>] registering for termination of '@NS<1>'
+daemon-2            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-2            : [@NS<0>:2:PID<?>] Debugging '@NS<1>'
+daemon-2            : [@NS<0>:2:PID<?>] my local rank 0
+daemon-2            : [@NS<0>:2:PID<?>] registering for termination of '@NS<1>'
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : cbfunc called as daemon callback for PMIx_Query
 daemon-2            : Transferring pmix.qry.lptable
-daemon-2            : [@NS<0>:2:@PID<2>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-2            : [@NS<0>:2:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-2            : Proctable[0], namespace @NS<1> rank 2 exec hello
 daemon-2            : Proctable[1], namespace @NS<1> rank 3 exec hello
 daemon-2            : Waiting for application namespace @NS<1> to terminate
 daemon-2            : release_fn called as daemon callback for event=JOB ENDED
 daemon-2            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-2            : Application namespace @NS<1> terminated
-daemon-2            : Debugger daemon ns @NS<0> rank 2 pid @PID<2>: Finalizing
-daemon-3            : Debugger daemon ns @NS<0> on host @HOST<1> rank 3 pid @PID<3>: Running
+daemon-2            : Debugger daemon ns @NS<0> rank 2 pid PID<?>: Finalizing
+daemon-3            : Debugger daemon ns @NS<0> on host <host> rank 3 pid PID<?>: Running
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
-daemon-3            : [@NS<0>:-2:@PID<3>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-3            : [@NS<0>:3:@PID<3>] Debugging '@NS<1>'
-daemon-3            : [@NS<0>:3:@PID<3>] my local rank 1
-daemon-3            : [@NS<0>:3:@PID<3>] registering for termination of '@NS<1>'
+daemon-3            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-3            : [@NS<0>:3:PID<?>] Debugging '@NS<1>'
+daemon-3            : [@NS<0>:3:PID<?>] my local rank 1
+daemon-3            : [@NS<0>:3:PID<?>] registering for termination of '@NS<1>'
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
 daemon-3            : cbfunc called as daemon callback for PMIx_Query
 daemon-3            : Transferring pmix.qry.lptable
-daemon-3            : [@NS<0>:3:@PID<3>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-3            : [@NS<0>:3:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-3            : Proctable[0], namespace @NS<1> rank 2 exec hello
 daemon-3            : Proctable[1], namespace @NS<1> rank 3 exec hello
 daemon-3            : Waiting for application namespace @NS<1> to terminate
 daemon-3            : release_fn called as daemon callback for event=JOB ENDED
 daemon-3            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-3            : Application namespace @NS<1> terminated
-daemon-3            : Debugger daemon ns @NS<0> rank 3 pid @PID<3>: Finalizing
-daemon-4            : Debugger daemon ns @NS<0> on host @HOST<2> rank 4 pid @PID<4>: Running
+daemon-3            : Debugger daemon ns @NS<0> rank 3 pid PID<?>: Finalizing
+daemon-4            : Debugger daemon ns @NS<0> on host <host> rank 4 pid PID<?>: Running
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
-daemon-4            : [@NS<0>:-2:@PID<4>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-4            : [@NS<0>:4:@PID<4>] Debugging '@NS<1>'
-daemon-4            : [@NS<0>:4:@PID<4>] my local rank 0
-daemon-4            : [@NS<0>:4:@PID<4>] registering for termination of '@NS<1>'
+daemon-4            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-4            : [@NS<0>:4:PID<?>] Debugging '@NS<1>'
+daemon-4            : [@NS<0>:4:PID<?>] my local rank 0
+daemon-4            : [@NS<0>:4:PID<?>] registering for termination of '@NS<1>'
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
 daemon-4            : cbfunc called as daemon callback for PMIx_Query
 daemon-4            : Transferring pmix.qry.lptable
-daemon-4            : [@NS<0>:4:@PID<4>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-4            : [@NS<0>:4:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-4            : Proctable[0], namespace @NS<1> rank 4 exec hello
 daemon-4            : Proctable[1], namespace @NS<1> rank 5 exec hello
 daemon-4            : Waiting for application namespace @NS<1> to terminate
 daemon-4            : release_fn called as daemon callback for event=JOB ENDED
 daemon-4            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-4            : Application namespace @NS<1> terminated
-daemon-4            : Debugger daemon ns @NS<0> rank 4 pid @PID<4>: Finalizing
-daemon-5            : Debugger daemon ns @NS<0> on host @HOST<2> rank 5 pid @PID<5>: Running
+daemon-4            : Debugger daemon ns @NS<0> rank 4 pid PID<?>: Finalizing
+daemon-5            : Debugger daemon ns @NS<0> on host <host> rank 5 pid PID<?>: Running
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
-daemon-5            : [@NS<0>:-2:@PID<5>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-5            : [@NS<0>:5:@PID<5>] Debugging '@NS<1>'
-daemon-5            : [@NS<0>:5:@PID<5>] my local rank 1
-daemon-5            : [@NS<0>:5:@PID<5>] registering for termination of '@NS<1>'
+daemon-5            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-5            : [@NS<0>:5:PID<?>] Debugging '@NS<1>'
+daemon-5            : [@NS<0>:5:PID<?>] my local rank 1
+daemon-5            : [@NS<0>:5:PID<?>] registering for termination of '@NS<1>'
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
 daemon-5            : cbfunc called as daemon callback for PMIx_Query
 daemon-5            : Transferring pmix.qry.lptable
-daemon-5            : [@NS<0>:5:@PID<5>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-5            : [@NS<0>:5:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-5            : Proctable[0], namespace @NS<1> rank 4 exec hello
 daemon-5            : Proctable[1], namespace @NS<1> rank 5 exec hello
 daemon-5            : Waiting for application namespace @NS<1> to terminate
 daemon-5            : release_fn called as daemon callback for event=JOB ENDED
 daemon-5            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-5            : Application namespace @NS<1> terminated
-daemon-5            : Debugger daemon ns @NS<0> rank 5 pid @PID<5>: Finalizing
-direct-multi        : Debugger ns @NS<2> rank 0 pid @PID<6>: Running
+daemon-5            : Debugger daemon ns @NS<0> rank 5 pid PID<?>: Finalizing
+direct-multi        : Debugger ns @NS<2> rank 0 pid PID<?>: Running
 direct-multi        : evhandler_reg_callbk called to register callback
 direct-multi        : Called cbfunc as callback for PMIx_Query
 direct-multi        : Key pmix.qry.spawn Type PMIX_STRING(3)
@@ -123,21 +123,21 @@ direct-multi        : release_fn called as callback for event=JOB ENDED source=@
 direct-multi        : DEBUGGER NOTIFIED THAT JOB @NS<1> TERMINATED 
 direct-multi        : release_fn called as callback for event=JOB ENDED source=@NS<0>:0
 direct-multi        : DEBUGGER NOTIFIED THAT JOB @NS<0> TERMINATED 
-hello-0             : Client ns @NS<1> rank 0 pid @PID<7>: Running on host @HOST<0> localrank 0
+hello-0             : Client ns @NS<1> rank 0 pid PID<?>: Running on host <host> localrank 0
 hello-0             : Client ns @NS<1> rank 0: Finalizing
 hello-0             : Client ns @NS<1> rank 0:PMIx_Finalize successfully completed
-hello-1             : Client ns @NS<1> rank 1 pid @PID<8>: Running on host @HOST<0> localrank 1
+hello-1             : Client ns @NS<1> rank 1 pid PID<?>: Running on host <host> localrank 1
 hello-1             : Client ns @NS<1> rank 1: Finalizing
 hello-1             : Client ns @NS<1> rank 1:PMIx_Finalize successfully completed
-hello-2             : Client ns @NS<1> rank 2 pid @PID<9>: Running on host @HOST<1> localrank 0
+hello-2             : Client ns @NS<1> rank 2 pid PID<?>: Running on host <host> localrank 0
 hello-2             : Client ns @NS<1> rank 2: Finalizing
 hello-2             : Client ns @NS<1> rank 2:PMIx_Finalize successfully completed
-hello-3             : Client ns @NS<1> rank 3 pid @PID<10>: Running on host @HOST<1> localrank 1
+hello-3             : Client ns @NS<1> rank 3 pid PID<?>: Running on host <host> localrank 1
 hello-3             : Client ns @NS<1> rank 3: Finalizing
 hello-3             : Client ns @NS<1> rank 3:PMIx_Finalize successfully completed
-hello-4             : Client ns @NS<1> rank 4 pid @PID<11>: Running on host @HOST<2> localrank 0
+hello-4             : Client ns @NS<1> rank 4 pid PID<?>: Running on host <host> localrank 0
 hello-4             : Client ns @NS<1> rank 4: Finalizing
 hello-4             : Client ns @NS<1> rank 4:PMIx_Finalize successfully completed
-hello-5             : Client ns @NS<1> rank 5 pid @PID<12>: Running on host @HOST<2> localrank 1
+hello-5             : Client ns @NS<1> rank 5 pid PID<?>: Running on host <host> localrank 1
 hello-5             : Client ns @NS<1> rank 5: Finalizing
 hello-5             : Client ns @NS<1> rank 5:PMIx_Finalize successfully completed

--- a/prrte/debug/direct-multi.stdout.baseline
+++ b/prrte/debug/direct-multi.stdout.baseline
@@ -1,56 +1,56 @@
-daemon-0            : Debugger daemon ns @NS<0> on host @HOST<0> rank 0 pid @PID<0>: Running
+daemon-0            : Debugger daemon ns @NS<0> on host <host> rank 0 pid PID<?>: Running
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
-daemon-0            : [@NS<0>:-2:@PID<0>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-0            : [@NS<0>:0:@PID<0>] Debugging '@NS<1>'
-daemon-0            : [@NS<0>:0:@PID<0>] my local rank 0
-daemon-0            : [@NS<0>:0:@PID<0>] registering for termination of '@NS<1>'
+daemon-0            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-0            : [@NS<0>:0:PID<?>] Debugging '@NS<1>'
+daemon-0            : [@NS<0>:0:PID<?>] my local rank 0
+daemon-0            : [@NS<0>:0:PID<?>] registering for termination of '@NS<1>'
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : Transferring pmix.qry.lptable
-daemon-0            : [@NS<0>:0:@PID<0>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-0            : [@NS<0>:0:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-0            : Proctable[0], namespace @NS<1> rank 0 exec hello
 daemon-0            : Proctable[1], namespace @NS<1> rank 1 exec hello
-daemon-0            : [@NS<0>:0:@PID<0>] Sending release
+daemon-0            : [@NS<0>:0:PID<?>] Sending release
 daemon-0            : Waiting for application namespace @NS<1> to terminate
 daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-0            : Application namespace @NS<1> terminated
-daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-1            : Debugger daemon ns @NS<0> on host @HOST<1> rank 1 pid @PID<1>: Running
+daemon-0            : Debugger daemon ns @NS<0> rank 0 pid PID<?>: Finalizing
+daemon-1            : Debugger daemon ns @NS<0> on host <host> rank 1 pid PID<?>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
-daemon-1            : [@NS<0>:-2:@PID<1>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-1            : [@NS<0>:1:@PID<1>] Debugging '@NS<1>'
-daemon-1            : [@NS<0>:1:@PID<1>] my local rank 0
-daemon-1            : [@NS<0>:1:@PID<1>] registering for termination of '@NS<1>'
+daemon-1            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-1            : [@NS<0>:1:PID<?>] Debugging '@NS<1>'
+daemon-1            : [@NS<0>:1:PID<?>] my local rank 0
+daemon-1            : [@NS<0>:1:PID<?>] registering for termination of '@NS<1>'
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : cbfunc called as daemon callback for PMIx_Query
 daemon-1            : Transferring pmix.qry.lptable
-daemon-1            : [@NS<0>:1:@PID<1>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-1            : [@NS<0>:1:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-1            : Proctable[0], namespace @NS<1> rank 2 exec hello
 daemon-1            : Proctable[1], namespace @NS<1> rank 3 exec hello
 daemon-1            : Waiting for application namespace @NS<1> to terminate
 daemon-1            : release_fn called as daemon callback for event=JOB ENDED
 daemon-1            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-1            : Application namespace @NS<1> terminated
-daemon-1            : Debugger daemon ns @NS<0> rank 1 pid @PID<1>: Finalizing
-daemon-2            : Debugger daemon ns @NS<0> on host @HOST<2> rank 2 pid @PID<2>: Running
+daemon-1            : Debugger daemon ns @NS<0> rank 1 pid PID<?>: Finalizing
+daemon-2            : Debugger daemon ns @NS<0> on host <host> rank 2 pid PID<?>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
-daemon-2            : [@NS<0>:-2:@PID<2>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-2            : [@NS<0>:2:@PID<2>] Debugging '@NS<1>'
-daemon-2            : [@NS<0>:2:@PID<2>] my local rank 0
-daemon-2            : [@NS<0>:2:@PID<2>] registering for termination of '@NS<1>'
+daemon-2            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-2            : [@NS<0>:2:PID<?>] Debugging '@NS<1>'
+daemon-2            : [@NS<0>:2:PID<?>] my local rank 0
+daemon-2            : [@NS<0>:2:PID<?>] registering for termination of '@NS<1>'
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : cbfunc called as daemon callback for PMIx_Query
 daemon-2            : Transferring pmix.qry.lptable
-daemon-2            : [@NS<0>:2:@PID<2>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-2            : [@NS<0>:2:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-2            : Proctable[0], namespace @NS<1> rank 4 exec hello
 daemon-2            : Proctable[1], namespace @NS<1> rank 5 exec hello
 daemon-2            : Waiting for application namespace @NS<1> to terminate
 daemon-2            : release_fn called as daemon callback for event=JOB ENDED
 daemon-2            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-2            : Application namespace @NS<1> terminated
-daemon-2            : Debugger daemon ns @NS<0> rank 2 pid @PID<2>: Finalizing
-direct-multi        : Debugger ns @NS<2> rank 0 pid @PID<3>: Running
+daemon-2            : Debugger daemon ns @NS<0> rank 2 pid PID<?>: Finalizing
+direct-multi        : Debugger ns @NS<2> rank 0 pid PID<?>: Running
 direct-multi        : evhandler_reg_callbk called to register callback
 direct-multi        : Called cbfunc as callback for PMIx_Query
 direct-multi        : Key pmix.qry.spawn Type PMIX_STRING(3)
@@ -72,21 +72,21 @@ direct-multi        : release_fn called as callback for event=JOB ENDED source=@
 direct-multi        : DEBUGGER NOTIFIED THAT JOB @NS<1> TERMINATED 
 direct-multi        : release_fn called as callback for event=JOB ENDED source=@NS<0>:0
 direct-multi        : DEBUGGER NOTIFIED THAT JOB @NS<0> TERMINATED 
-hello-0             : Client ns @NS<1> rank 0 pid @PID<4>: Running on host @HOST<0> localrank 0
+hello-0             : Client ns @NS<1> rank 0 pid PID<?>: Running on host <host> localrank 0
 hello-0             : Client ns @NS<1> rank 0: Finalizing
 hello-0             : Client ns @NS<1> rank 0:PMIx_Finalize successfully completed
-hello-1             : Client ns @NS<1> rank 1 pid @PID<5>: Running on host @HOST<0> localrank 1
+hello-1             : Client ns @NS<1> rank 1 pid PID<?>: Running on host <host> localrank 1
 hello-1             : Client ns @NS<1> rank 1: Finalizing
 hello-1             : Client ns @NS<1> rank 1:PMIx_Finalize successfully completed
-hello-2             : Client ns @NS<1> rank 2 pid @PID<6>: Running on host @HOST<1> localrank 0
+hello-2             : Client ns @NS<1> rank 2 pid PID<?>: Running on host <host> localrank 0
 hello-2             : Client ns @NS<1> rank 2: Finalizing
 hello-2             : Client ns @NS<1> rank 2:PMIx_Finalize successfully completed
-hello-3             : Client ns @NS<1> rank 3 pid @PID<7>: Running on host @HOST<1> localrank 1
+hello-3             : Client ns @NS<1> rank 3 pid PID<?>: Running on host <host> localrank 1
 hello-3             : Client ns @NS<1> rank 3: Finalizing
 hello-3             : Client ns @NS<1> rank 3:PMIx_Finalize successfully completed
-hello-4             : Client ns @NS<1> rank 4 pid @PID<8>: Running on host @HOST<2> localrank 0
+hello-4             : Client ns @NS<1> rank 4 pid PID<?>: Running on host <host> localrank 0
 hello-4             : Client ns @NS<1> rank 4: Finalizing
 hello-4             : Client ns @NS<1> rank 4:PMIx_Finalize successfully completed
-hello-5             : Client ns @NS<1> rank 5 pid @PID<9>: Running on host @HOST<2> localrank 1
+hello-5             : Client ns @NS<1> rank 5 pid PID<?>: Running on host <host> localrank 1
 hello-5             : Client ns @NS<1> rank 5: Finalizing
 hello-5             : Client ns @NS<1> rank 5:PMIx_Finalize successfully completed

--- a/prrte/debug/direct.stdout.baseline
+++ b/prrte/debug/direct.stdout.baseline
@@ -1,22 +1,22 @@
-daemon-0            : Debugger daemon ns @NS<0> on host @HOST<0> rank 0 pid @PID<0>: Running
+daemon-0            : Debugger daemon ns @NS<0> on host <host> rank 0 pid PID<?>: Running
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
-daemon-0            : [@NS<0>:-2:@PID<0>] PMIX_DEBUG_JOB is '@NS<1>'
-daemon-0            : [@NS<0>:0:@PID<0>] Debugging '@NS<1>'
-daemon-0            : [@NS<0>:0:@PID<0>] my local rank 0
-daemon-0            : [@NS<0>:0:@PID<0>] registering for termination of '@NS<1>'
+daemon-0            : [@NS<0>:-2:PID<?>] PMIX_DEBUG_JOB is '@NS<1>'
+daemon-0            : [@NS<0>:0:PID<?>] Debugging '@NS<1>'
+daemon-0            : [@NS<0>:0:PID<?>] my local rank 0
+daemon-0            : [@NS<0>:0:PID<?>] registering for termination of '@NS<1>'
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : Transferring pmix.qry.lptable
-daemon-0            : [@NS<0>:0:@PID<0>] Local proctable received for nspace '@NS<1>' has 2 entries
+daemon-0            : [@NS<0>:0:PID<?>] Local proctable received for nspace '@NS<1>' has 2 entries
 daemon-0            : Proctable[0], namespace @NS<1> rank 0 exec hello
 daemon-0            : Proctable[1], namespace @NS<1> rank 1 exec hello
-daemon-0            : [@NS<0>:0:@PID<0>] Sending release
+daemon-0            : [@NS<0>:0:PID<?>] Sending release
 daemon-0            : Waiting for application namespace @NS<1> to terminate
 daemon-0            : release_fn called as daemon callback for event=JOB ENDED
 daemon-0            : DEBUGGER DAEMON NAMESPACE @NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @NS<1>
 daemon-0            : Application namespace @NS<1> terminated
-daemon-0            : Debugger daemon ns @NS<0> rank 0 pid @PID<0>: Finalizing
-direct              : Debugger ns @NS<2> rank 0 pid @PID<1>: Running
+daemon-0            : Debugger daemon ns @NS<0> rank 0 pid PID<?>: Finalizing
+direct              : Debugger ns @NS<2> rank 0 pid PID<?>: Running
 direct              : Connected system server is @NS<3>:0
 direct              : evhandler_reg_callbk called to register callback
 direct              : Called cbfunc as callback for PMIx_Query
@@ -41,9 +41,9 @@ direct              : release_fn called as callback for event=JOB ENDED source=@
 direct              : DEBUGGER NOTIFIED THAT JOB @NS<1> TERMINATED 
 direct              : release_fn called as callback for event=JOB ENDED source=@NS<0>:0
 direct              : DEBUGGER NOTIFIED THAT JOB @NS<0> TERMINATED 
-hello-0             : Client ns @NS<1> rank 0 pid @PID<2>: Running on host @HOST<0> localrank 0
+hello-0             : Client ns @NS<1> rank 0 pid PID<?>: Running on host <host> localrank 0
 hello-0             : Client ns @NS<1> rank 0: Finalizing
 hello-0             : Client ns @NS<1> rank 0:PMIx_Finalize successfully completed
-hello-1             : Client ns @NS<1> rank 1 pid @PID<3>: Running on host @HOST<0> localrank 1
+hello-1             : Client ns @NS<1> rank 1 pid PID<?>: Running on host <host> localrank 1
 hello-1             : Client ns @NS<1> rank 1: Finalizing
 hello-1             : Client ns @NS<1> rank 1:PMIx_Finalize successfully completed

--- a/prrte/debug/indirect-colaunch1.stdout.baseline
+++ b/prrte/debug/indirect-colaunch1.stdout.baseline
@@ -1,99 +1,91 @@
-daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<0> rank 0 pid @PID<0>: Running
+daemon-0            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 0 pid PID<?>: Running
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<0>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] my local rank 0
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-0            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] my local rank 0
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : Transferring pmix.qry.lptable
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-0            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 0 exec hello
-daemon-0            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 1 exec hello
-daemon-0            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 2 exec hello
-daemon-0            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 3 exec hello
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] Sending release
-daemon-0            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-0            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 0 exec hello
+daemon-0            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 1 exec hello
+daemon-0            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 2 exec hello
+daemon-0            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 3 exec hello
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] Sending release
+daemon-0            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
 daemon-0            : release_fn called as daemon callback for event=JOB ENDED
-daemon-0            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-0            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 1 pid @PID<2>: Running
+daemon-0            : DEBUGGER DAEMON NAMESPACE <host>:PID<?>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED <host>:PID<?>:@NS<2>
+daemon-0            : Application namespace <host>:PID<?>:@NS<2> terminated
+daemon-0            : Debugger daemon ns <host>:PID<?>:@NS<0> rank 0 pid PID<?>: Finalizing
+daemon-1            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 1 pid PID<?>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<2>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] my local rank 0
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-1            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] my local rank 0
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : cbfunc called as daemon callback for PMIx_Query
 daemon-1            : Transferring pmix.qry.lptable
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-1            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 4 exec hello
-daemon-1            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 5 exec hello
-daemon-1            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 6 exec hello
-daemon-1            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 7 exec hello
-daemon-1            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-1            : release_fn called as daemon callback for event=JOB ENDED
-daemon-1            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-1            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 1 pid @PID<2>: Finalizing
-daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 2 pid @PID<3>: Running
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-1            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 4 exec hello
+daemon-1            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 5 exec hello
+daemon-1            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 6 exec hello
+daemon-1            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 7 exec hello
+daemon-1            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+daemon-2            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 2 pid PID<?>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<3>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<3>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<3>] my local rank 0
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<3>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-2            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] my local rank 0
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : cbfunc called as daemon callback for PMIx_Query
 daemon-2            : Transferring pmix.qry.lptable
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<3>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-2            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 8 exec hello
-daemon-2            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 9 exec hello
-daemon-2            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 10 exec hello
-daemon-2            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 11 exec hello
-daemon-2            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-2            : release_fn called as daemon callback for event=JOB ENDED
-daemon-2            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-2            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 2 pid @PID<3>: Finalizing
-hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0 pid @PID<4>: Running on host @HOST<0> localrank 0
-hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0: Finalizing
-hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0:PMIx_Finalize successfully completed
-hello-1             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 1 pid @PID<5>: Running on host @HOST<0> localrank 1
-hello-1             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 1: Finalizing
-hello-1             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 1:PMIx_Finalize successfully completed
-hello-10            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 10 pid @PID<6>: Running on host @HOST<3> localrank 2
-hello-10            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 10: Finalizing
-hello-10            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 10:PMIx_Finalize successfully completed
-hello-11            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 11 pid @PID<7>: Running on host @HOST<3> localrank 3
-hello-11            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 11: Finalizing
-hello-11            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 11:PMIx_Finalize successfully completed
-hello-2             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 2 pid @PID<8>: Running on host @HOST<0> localrank 2
-hello-2             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 2: Finalizing
-hello-2             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 2:PMIx_Finalize successfully completed
-hello-3             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 3 pid @PID<9>: Running on host @HOST<0> localrank 3
-hello-3             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 3: Finalizing
-hello-3             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 3:PMIx_Finalize successfully completed
-hello-4             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 4 pid @PID<10>: Running on host @HOST<2> localrank 0
-hello-4             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 4: Finalizing
-hello-4             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 4:PMIx_Finalize successfully completed
-hello-5             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 5 pid @PID<11>: Running on host @HOST<2> localrank 1
-hello-5             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 5: Finalizing
-hello-5             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 5:PMIx_Finalize successfully completed
-hello-6             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 6 pid @PID<12>: Running on host @HOST<2> localrank 2
-hello-6             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 6: Finalizing
-hello-6             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 6:PMIx_Finalize successfully completed
-hello-7             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 7 pid @PID<13>: Running on host @HOST<2> localrank 3
-hello-7             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 7: Finalizing
-hello-7             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 7:PMIx_Finalize successfully completed
-hello-8             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 8 pid @PID<14>: Running on host @HOST<3> localrank 0
-hello-8             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 8: Finalizing
-hello-8             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 8:PMIx_Finalize successfully completed
-hello-9             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 9 pid @PID<15>: Running on host @HOST<3> localrank 1
-hello-9             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 9: Finalizing
-hello-9             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 9:PMIx_Finalize successfully completed
-indirect-multi      : Debugger ns @NS<3> rank 0 pid @PID<1>: Running
-indirect-multi      : Debugger URI: @NS<4>;tcp4://@HOST<4>
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-2            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 8 exec hello
+daemon-2            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 9 exec hello
+daemon-2            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 10 exec hello
+daemon-2            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 11 exec hello
+daemon-2            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+hello-0             : Client ns <host>:PID<?>:@NS<2> rank 0 pid PID<?>: Running on host <host> localrank 0
+hello-0             : Client ns <host>:PID<?>:@NS<2> rank 0: Finalizing
+hello-0             : Client ns <host>:PID<?>:@NS<2> rank 0:PMIx_Finalize successfully completed
+hello-1             : Client ns <host>:PID<?>:@NS<2> rank 1 pid PID<?>: Running on host <host> localrank 1
+hello-1             : Client ns <host>:PID<?>:@NS<2> rank 1: Finalizing
+hello-1             : Client ns <host>:PID<?>:@NS<2> rank 1:PMIx_Finalize successfully completed
+hello-10            : Client ns <host>:PID<?>:@NS<2> rank 10 pid PID<?>: Running on host <host> localrank 2
+hello-10            : Client ns <host>:PID<?>:@NS<2> rank 10: Finalizing
+hello-10            : Client ns <host>:PID<?>:@NS<2> rank 10:PMIx_Finalize successfully completed
+hello-11            : Client ns <host>:PID<?>:@NS<2> rank 11 pid PID<?>: Running on host <host> localrank 3
+hello-11            : Client ns <host>:PID<?>:@NS<2> rank 11: Finalizing
+hello-11            : Client ns <host>:PID<?>:@NS<2> rank 11:PMIx_Finalize successfully completed
+hello-2             : Client ns <host>:PID<?>:@NS<2> rank 2 pid PID<?>: Running on host <host> localrank 2
+hello-2             : Client ns <host>:PID<?>:@NS<2> rank 2: Finalizing
+hello-2             : Client ns <host>:PID<?>:@NS<2> rank 2:PMIx_Finalize successfully completed
+hello-3             : Client ns <host>:PID<?>:@NS<2> rank 3 pid PID<?>: Running on host <host> localrank 3
+hello-3             : Client ns <host>:PID<?>:@NS<2> rank 3: Finalizing
+hello-3             : Client ns <host>:PID<?>:@NS<2> rank 3:PMIx_Finalize successfully completed
+hello-4             : Client ns <host>:PID<?>:@NS<2> rank 4 pid PID<?>: Running on host <host> localrank 0
+hello-4             : Client ns <host>:PID<?>:@NS<2> rank 4: Finalizing
+hello-4             : Client ns <host>:PID<?>:@NS<2> rank 4:PMIx_Finalize successfully completed
+hello-5             : Client ns <host>:PID<?>:@NS<2> rank 5 pid PID<?>: Running on host <host> localrank 1
+hello-5             : Client ns <host>:PID<?>:@NS<2> rank 5: Finalizing
+hello-5             : Client ns <host>:PID<?>:@NS<2> rank 5:PMIx_Finalize successfully completed
+hello-6             : Client ns <host>:PID<?>:@NS<2> rank 6 pid PID<?>: Running on host <host> localrank 2
+hello-6             : Client ns <host>:PID<?>:@NS<2> rank 6: Finalizing
+hello-6             : Client ns <host>:PID<?>:@NS<2> rank 6:PMIx_Finalize successfully completed
+hello-7             : Client ns <host>:PID<?>:@NS<2> rank 7 pid PID<?>: Running on host <host> localrank 3
+hello-7             : Client ns <host>:PID<?>:@NS<2> rank 7: Finalizing
+hello-7             : Client ns <host>:PID<?>:@NS<2> rank 7:PMIx_Finalize successfully completed
+hello-8             : Client ns <host>:PID<?>:@NS<2> rank 8 pid PID<?>: Running on host <host> localrank 0
+hello-8             : Client ns <host>:PID<?>:@NS<2> rank 8: Finalizing
+hello-8             : Client ns <host>:PID<?>:@NS<2> rank 8:PMIx_Finalize successfully completed
+hello-9             : Client ns <host>:PID<?>:@NS<2> rank 9 pid PID<?>: Running on host <host> localrank 1
+hello-9             : Client ns <host>:PID<?>:@NS<2> rank 9: Finalizing
+hello-9             : Client ns <host>:PID<?>:@NS<2> rank 9:PMIx_Finalize successfully completed
+indirect-multi      : Debugger ns @NS<3> rank 0 pid PID<?>: Running
+indirect-multi      : Debugger URI: @NS<4>;tcp4://<host>
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Spawning launcher
@@ -103,11 +95,11 @@ indirect-multi      : Registering READY-FOR-DEBUG handler
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Releasing prterun [@NS<5>,0]
 indirect-multi      : Waiting for application launch
-indirect-multi      : Got READY-FOR-DEBUG event from nspace @HOST<1>:@PID<1>:@NS<6>
-indirect-multi      : Debugger daemon job: @HOST<1>:@PID<1>:@NS<2>
-indirect-multi      : Application has launched: @HOST<1>:@PID<1>:@NS<2>
+indirect-multi      : Got READY-FOR-DEBUG event from nspace <host>:PID<?>:@NS<6>
+indirect-multi      : Debugger daemon job: <host>:PID<?>:@NS<2>
+indirect-multi      : Application has launched: <host>:PID<?>:@NS<2>
 indirect-multi      : Debugger: spawning ./daemon
-indirect-multi      : Debugger nspace: @HOST<1>:@PID<1>:@NS<0>
+indirect-multi      : Debugger nspace: <host>:PID<?>:@NS<0>
 indirect-multi      : Registering handler for debugger termination
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Waiting for IL to terminate

--- a/prrte/debug/indirect-colaunch2.stdout.baseline
+++ b/prrte/debug/indirect-colaunch2.stdout.baseline
@@ -1,270 +1,238 @@
-daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<0> rank 0 pid @PID<0>: Running
+daemon-0            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 0 pid PID<?>: Running
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<0>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] my local rank 0
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-0            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] my local rank 0
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : Transferring pmix.qry.lptable
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-0            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 0 exec hello
-daemon-0            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 1 exec hello
-daemon-0            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 2 exec hello
-daemon-0            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 3 exec hello
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] Sending release
-daemon-0            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-0            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 0 exec hello
+daemon-0            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 1 exec hello
+daemon-0            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 2 exec hello
+daemon-0            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 3 exec hello
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] Sending release
+daemon-0            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
 daemon-0            : release_fn called as daemon callback for event=JOB ENDED
-daemon-0            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-0            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<0> rank 1 pid @PID<2>: Running
+daemon-0            : DEBUGGER DAEMON NAMESPACE <host>:PID<?>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED <host>:PID<?>:@NS<2>
+daemon-0            : Application namespace <host>:PID<?>:@NS<2> terminated
+daemon-0            : Debugger daemon ns <host>:PID<?>:@NS<0> rank 0 pid PID<?>: Finalizing
+daemon-1            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 1 pid PID<?>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<2>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] my local rank 1
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-1            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] my local rank 1
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : cbfunc called as daemon callback for PMIx_Query
 daemon-1            : Transferring pmix.qry.lptable
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-1            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 0 exec hello
-daemon-1            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 1 exec hello
-daemon-1            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 2 exec hello
-daemon-1            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 3 exec hello
-daemon-1            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-1            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 0 exec hello
+daemon-1            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 1 exec hello
+daemon-1            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 2 exec hello
+daemon-1            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 3 exec hello
+daemon-1            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
 daemon-1            : release_fn called as daemon callback for event=JOB ENDED
-daemon-1            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-1            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 1 pid @PID<2>: Finalizing
-daemon-10           : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 10 pid @PID<3>: Running
+daemon-1            : DEBUGGER DAEMON NAMESPACE <host>:PID<?>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED <host>:PID<?>:@NS<2>
+daemon-1            : Application namespace <host>:PID<?>:@NS<2> terminated
+daemon-1            : Debugger daemon ns <host>:PID<?>:@NS<0> rank 1 pid PID<?>: Finalizing
+daemon-10           : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 10 pid PID<?>: Running
 daemon-10           : evhandler_reg_callbk called by daemon as registration callback
-daemon-10           : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<3>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-10           : [@HOST<1>:@PID<1>:@NS<1>@2:10:@PID<3>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-10           : [@HOST<1>:@PID<1>:@NS<1>@2:10:@PID<3>] my local rank 2
-daemon-10           : [@HOST<1>:@PID<1>:@NS<1>@2:10:@PID<3>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-10           : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-10           : [<host>:PID<?>:@NS<1>@2:10:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-10           : [<host>:PID<?>:@NS<1>@2:10:PID<?>] my local rank 2
+daemon-10           : [<host>:PID<?>:@NS<1>@2:10:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-10           : evhandler_reg_callbk called by daemon as registration callback
 daemon-10           : cbfunc called as daemon callback for PMIx_Query
 daemon-10           : Transferring pmix.qry.lptable
-daemon-10           : [@HOST<1>:@PID<1>:@NS<1>@2:10:@PID<3>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-10           : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 8 exec hello
-daemon-10           : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 9 exec hello
-daemon-10           : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 10 exec hello
-daemon-10           : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 11 exec hello
-daemon-10           : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-10           : release_fn called as daemon callback for event=JOB ENDED
-daemon-10           : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-10           : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-10           : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 10 pid @PID<3>: Finalizing
-daemon-11           : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 11 pid @PID<4>: Running
+daemon-10           : [<host>:PID<?>:@NS<1>@2:10:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-10           : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 8 exec hello
+daemon-10           : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 9 exec hello
+daemon-10           : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 10 exec hello
+daemon-10           : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 11 exec hello
+daemon-10           : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+daemon-11           : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 11 pid PID<?>: Running
 daemon-11           : evhandler_reg_callbk called by daemon as registration callback
-daemon-11           : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<4>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-11           : [@HOST<1>:@PID<1>:@NS<1>@2:11:@PID<4>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-11           : [@HOST<1>:@PID<1>:@NS<1>@2:11:@PID<4>] my local rank 3
-daemon-11           : [@HOST<1>:@PID<1>:@NS<1>@2:11:@PID<4>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-11           : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-11           : [<host>:PID<?>:@NS<1>@2:11:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-11           : [<host>:PID<?>:@NS<1>@2:11:PID<?>] my local rank 3
+daemon-11           : [<host>:PID<?>:@NS<1>@2:11:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-11           : evhandler_reg_callbk called by daemon as registration callback
 daemon-11           : cbfunc called as daemon callback for PMIx_Query
 daemon-11           : Transferring pmix.qry.lptable
-daemon-11           : [@HOST<1>:@PID<1>:@NS<1>@2:11:@PID<4>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-11           : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 8 exec hello
-daemon-11           : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 9 exec hello
-daemon-11           : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 10 exec hello
-daemon-11           : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 11 exec hello
-daemon-11           : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-11           : release_fn called as daemon callback for event=JOB ENDED
-daemon-11           : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-11           : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-11           : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 11 pid @PID<4>: Finalizing
-daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<0> rank 2 pid @PID<5>: Running
+daemon-11           : [<host>:PID<?>:@NS<1>@2:11:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-11           : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 8 exec hello
+daemon-11           : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 9 exec hello
+daemon-11           : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 10 exec hello
+daemon-11           : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 11 exec hello
+daemon-11           : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+daemon-2            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 2 pid PID<?>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<5>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<5>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<5>] my local rank 2
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<5>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-2            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] my local rank 2
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : cbfunc called as daemon callback for PMIx_Query
 daemon-2            : Transferring pmix.qry.lptable
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<5>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-2            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 0 exec hello
-daemon-2            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 1 exec hello
-daemon-2            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 2 exec hello
-daemon-2            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 3 exec hello
-daemon-2            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-2            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 0 exec hello
+daemon-2            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 1 exec hello
+daemon-2            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 2 exec hello
+daemon-2            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 3 exec hello
+daemon-2            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
 daemon-2            : release_fn called as daemon callback for event=JOB ENDED
-daemon-2            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-2            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 2 pid @PID<5>: Finalizing
-daemon-3            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<0> rank 3 pid @PID<6>: Running
+daemon-2            : DEBUGGER DAEMON NAMESPACE <host>:PID<?>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED <host>:PID<?>:@NS<2>
+daemon-2            : Application namespace <host>:PID<?>:@NS<2> terminated
+daemon-2            : Debugger daemon ns <host>:PID<?>:@NS<0> rank 2 pid PID<?>: Finalizing
+daemon-3            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 3 pid PID<?>: Running
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
-daemon-3            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<6>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-3            : [@HOST<1>:@PID<1>:@NS<1>@2:3:@PID<6>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-3            : [@HOST<1>:@PID<1>:@NS<1>@2:3:@PID<6>] my local rank 3
-daemon-3            : [@HOST<1>:@PID<1>:@NS<1>@2:3:@PID<6>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-3            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-3            : [<host>:PID<?>:@NS<1>@2:3:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-3            : [<host>:PID<?>:@NS<1>@2:3:PID<?>] my local rank 3
+daemon-3            : [<host>:PID<?>:@NS<1>@2:3:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-3            : evhandler_reg_callbk called by daemon as registration callback
 daemon-3            : cbfunc called as daemon callback for PMIx_Query
 daemon-3            : Transferring pmix.qry.lptable
-daemon-3            : [@HOST<1>:@PID<1>:@NS<1>@2:3:@PID<6>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-3            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 0 exec hello
-daemon-3            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 1 exec hello
-daemon-3            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 2 exec hello
-daemon-3            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 3 exec hello
-daemon-3            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
+daemon-3            : [<host>:PID<?>:@NS<1>@2:3:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-3            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 0 exec hello
+daemon-3            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 1 exec hello
+daemon-3            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 2 exec hello
+daemon-3            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 3 exec hello
+daemon-3            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
 daemon-3            : release_fn called as daemon callback for event=JOB ENDED
-daemon-3            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-3            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-3            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 3 pid @PID<6>: Finalizing
-daemon-4            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 4 pid @PID<7>: Running
+daemon-3            : DEBUGGER DAEMON NAMESPACE <host>:PID<?>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED <host>:PID<?>:@NS<2>
+daemon-3            : Application namespace <host>:PID<?>:@NS<2> terminated
+daemon-3            : Debugger daemon ns <host>:PID<?>:@NS<0> rank 3 pid PID<?>: Finalizing
+daemon-4            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 4 pid PID<?>: Running
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
-daemon-4            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<7>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-4            : [@HOST<1>:@PID<1>:@NS<1>@2:4:@PID<7>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-4            : [@HOST<1>:@PID<1>:@NS<1>@2:4:@PID<7>] my local rank 0
-daemon-4            : [@HOST<1>:@PID<1>:@NS<1>@2:4:@PID<7>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-4            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-4            : [<host>:PID<?>:@NS<1>@2:4:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-4            : [<host>:PID<?>:@NS<1>@2:4:PID<?>] my local rank 0
+daemon-4            : [<host>:PID<?>:@NS<1>@2:4:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-4            : evhandler_reg_callbk called by daemon as registration callback
 daemon-4            : cbfunc called as daemon callback for PMIx_Query
 daemon-4            : Transferring pmix.qry.lptable
-daemon-4            : [@HOST<1>:@PID<1>:@NS<1>@2:4:@PID<7>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-4            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 4 exec hello
-daemon-4            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 5 exec hello
-daemon-4            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 6 exec hello
-daemon-4            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 7 exec hello
-daemon-4            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-4            : release_fn called as daemon callback for event=JOB ENDED
-daemon-4            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-4            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-4            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 4 pid @PID<7>: Finalizing
-daemon-5            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 5 pid @PID<8>: Running
+daemon-4            : [<host>:PID<?>:@NS<1>@2:4:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-4            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 4 exec hello
+daemon-4            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 5 exec hello
+daemon-4            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 6 exec hello
+daemon-4            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 7 exec hello
+daemon-4            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+daemon-5            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 5 pid PID<?>: Running
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
-daemon-5            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<8>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-5            : [@HOST<1>:@PID<1>:@NS<1>@2:5:@PID<8>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-5            : [@HOST<1>:@PID<1>:@NS<1>@2:5:@PID<8>] my local rank 1
-daemon-5            : [@HOST<1>:@PID<1>:@NS<1>@2:5:@PID<8>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-5            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-5            : [<host>:PID<?>:@NS<1>@2:5:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-5            : [<host>:PID<?>:@NS<1>@2:5:PID<?>] my local rank 1
+daemon-5            : [<host>:PID<?>:@NS<1>@2:5:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-5            : evhandler_reg_callbk called by daemon as registration callback
 daemon-5            : cbfunc called as daemon callback for PMIx_Query
 daemon-5            : Transferring pmix.qry.lptable
-daemon-5            : [@HOST<1>:@PID<1>:@NS<1>@2:5:@PID<8>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-5            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 4 exec hello
-daemon-5            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 5 exec hello
-daemon-5            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 6 exec hello
-daemon-5            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 7 exec hello
-daemon-5            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-5            : release_fn called as daemon callback for event=JOB ENDED
-daemon-5            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-5            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-5            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 5 pid @PID<8>: Finalizing
-daemon-6            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 6 pid @PID<9>: Running
+daemon-5            : [<host>:PID<?>:@NS<1>@2:5:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-5            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 4 exec hello
+daemon-5            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 5 exec hello
+daemon-5            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 6 exec hello
+daemon-5            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 7 exec hello
+daemon-5            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+daemon-6            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 6 pid PID<?>: Running
 daemon-6            : evhandler_reg_callbk called by daemon as registration callback
-daemon-6            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<9>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-6            : [@HOST<1>:@PID<1>:@NS<1>@2:6:@PID<9>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-6            : [@HOST<1>:@PID<1>:@NS<1>@2:6:@PID<9>] my local rank 2
-daemon-6            : [@HOST<1>:@PID<1>:@NS<1>@2:6:@PID<9>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-6            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-6            : [<host>:PID<?>:@NS<1>@2:6:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-6            : [<host>:PID<?>:@NS<1>@2:6:PID<?>] my local rank 2
+daemon-6            : [<host>:PID<?>:@NS<1>@2:6:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-6            : evhandler_reg_callbk called by daemon as registration callback
 daemon-6            : cbfunc called as daemon callback for PMIx_Query
 daemon-6            : Transferring pmix.qry.lptable
-daemon-6            : [@HOST<1>:@PID<1>:@NS<1>@2:6:@PID<9>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-6            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 4 exec hello
-daemon-6            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 5 exec hello
-daemon-6            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 6 exec hello
-daemon-6            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 7 exec hello
-daemon-6            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-6            : release_fn called as daemon callback for event=JOB ENDED
-daemon-6            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-6            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-6            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 6 pid @PID<9>: Finalizing
-daemon-7            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 7 pid @PID<10>: Running
+daemon-6            : [<host>:PID<?>:@NS<1>@2:6:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-6            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 4 exec hello
+daemon-6            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 5 exec hello
+daemon-6            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 6 exec hello
+daemon-6            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 7 exec hello
+daemon-6            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+daemon-7            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 7 pid PID<?>: Running
 daemon-7            : evhandler_reg_callbk called by daemon as registration callback
-daemon-7            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<10>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-7            : [@HOST<1>:@PID<1>:@NS<1>@2:7:@PID<10>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-7            : [@HOST<1>:@PID<1>:@NS<1>@2:7:@PID<10>] my local rank 3
-daemon-7            : [@HOST<1>:@PID<1>:@NS<1>@2:7:@PID<10>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-7            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-7            : [<host>:PID<?>:@NS<1>@2:7:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-7            : [<host>:PID<?>:@NS<1>@2:7:PID<?>] my local rank 3
+daemon-7            : [<host>:PID<?>:@NS<1>@2:7:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-7            : evhandler_reg_callbk called by daemon as registration callback
 daemon-7            : cbfunc called as daemon callback for PMIx_Query
 daemon-7            : Transferring pmix.qry.lptable
-daemon-7            : [@HOST<1>:@PID<1>:@NS<1>@2:7:@PID<10>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-7            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 4 exec hello
-daemon-7            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 5 exec hello
-daemon-7            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 6 exec hello
-daemon-7            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 7 exec hello
-daemon-7            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-7            : release_fn called as daemon callback for event=JOB ENDED
-daemon-7            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-7            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-7            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 7 pid @PID<10>: Finalizing
-daemon-8            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 8 pid @PID<11>: Running
+daemon-7            : [<host>:PID<?>:@NS<1>@2:7:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-7            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 4 exec hello
+daemon-7            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 5 exec hello
+daemon-7            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 6 exec hello
+daemon-7            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 7 exec hello
+daemon-7            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+daemon-8            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 8 pid PID<?>: Running
 daemon-8            : evhandler_reg_callbk called by daemon as registration callback
-daemon-8            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<11>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-8            : [@HOST<1>:@PID<1>:@NS<1>@2:8:@PID<11>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-8            : [@HOST<1>:@PID<1>:@NS<1>@2:8:@PID<11>] my local rank 0
-daemon-8            : [@HOST<1>:@PID<1>:@NS<1>@2:8:@PID<11>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-8            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-8            : [<host>:PID<?>:@NS<1>@2:8:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-8            : [<host>:PID<?>:@NS<1>@2:8:PID<?>] my local rank 0
+daemon-8            : [<host>:PID<?>:@NS<1>@2:8:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-8            : evhandler_reg_callbk called by daemon as registration callback
 daemon-8            : cbfunc called as daemon callback for PMIx_Query
 daemon-8            : Transferring pmix.qry.lptable
-daemon-8            : [@HOST<1>:@PID<1>:@NS<1>@2:8:@PID<11>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-8            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 8 exec hello
-daemon-8            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 9 exec hello
-daemon-8            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 10 exec hello
-daemon-8            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 11 exec hello
-daemon-8            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-8            : release_fn called as daemon callback for event=JOB ENDED
-daemon-8            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-8            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-8            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 8 pid @PID<11>: Finalizing
-daemon-9            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 9 pid @PID<12>: Running
+daemon-8            : [<host>:PID<?>:@NS<1>@2:8:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-8            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 8 exec hello
+daemon-8            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 9 exec hello
+daemon-8            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 10 exec hello
+daemon-8            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 11 exec hello
+daemon-8            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+daemon-9            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 9 pid PID<?>: Running
 daemon-9            : evhandler_reg_callbk called by daemon as registration callback
-daemon-9            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<12>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-9            : [@HOST<1>:@PID<1>:@NS<1>@2:9:@PID<12>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-9            : [@HOST<1>:@PID<1>:@NS<1>@2:9:@PID<12>] my local rank 1
-daemon-9            : [@HOST<1>:@PID<1>:@NS<1>@2:9:@PID<12>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-9            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-9            : [<host>:PID<?>:@NS<1>@2:9:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-9            : [<host>:PID<?>:@NS<1>@2:9:PID<?>] my local rank 1
+daemon-9            : [<host>:PID<?>:@NS<1>@2:9:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-9            : evhandler_reg_callbk called by daemon as registration callback
 daemon-9            : cbfunc called as daemon callback for PMIx_Query
 daemon-9            : Transferring pmix.qry.lptable
-daemon-9            : [@HOST<1>:@PID<1>:@NS<1>@2:9:@PID<12>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 4 entries
-daemon-9            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 8 exec hello
-daemon-9            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 9 exec hello
-daemon-9            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 10 exec hello
-daemon-9            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 11 exec hello
-daemon-9            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-9            : release_fn called as daemon callback for event=JOB ENDED
-daemon-9            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-9            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-9            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 9 pid @PID<12>: Finalizing
-hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0 pid @PID<13>: Running on host @HOST<0> localrank 0
-hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0: Finalizing
-hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0:PMIx_Finalize successfully completed
-hello-1             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 1 pid @PID<14>: Running on host @HOST<0> localrank 1
-hello-1             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 1: Finalizing
-hello-1             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 1:PMIx_Finalize successfully completed
-hello-10            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 10 pid @PID<15>: Running on host @HOST<2> localrank 2
-hello-10            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 10: Finalizing
-hello-10            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 10:PMIx_Finalize successfully completed
-hello-11            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 11 pid @PID<16>: Running on host @HOST<2> localrank 3
-hello-11            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 11: Finalizing
-hello-11            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 11:PMIx_Finalize successfully completed
-hello-2             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 2 pid @PID<17>: Running on host @HOST<0> localrank 2
-hello-2             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 2: Finalizing
-hello-2             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 2:PMIx_Finalize successfully completed
-hello-3             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 3 pid @PID<18>: Running on host @HOST<0> localrank 3
-hello-3             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 3: Finalizing
-hello-3             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 3:PMIx_Finalize successfully completed
-hello-4             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 4 pid @PID<19>: Running on host @HOST<3> localrank 0
-hello-4             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 4: Finalizing
-hello-4             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 4:PMIx_Finalize successfully completed
-hello-5             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 5 pid @PID<20>: Running on host @HOST<3> localrank 1
-hello-5             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 5: Finalizing
-hello-5             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 5:PMIx_Finalize successfully completed
-hello-6             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 6 pid @PID<21>: Running on host @HOST<3> localrank 2
-hello-6             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 6: Finalizing
-hello-6             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 6:PMIx_Finalize successfully completed
-hello-7             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 7 pid @PID<22>: Running on host @HOST<3> localrank 3
-hello-7             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 7: Finalizing
-hello-7             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 7:PMIx_Finalize successfully completed
-hello-8             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 8 pid @PID<23>: Running on host @HOST<2> localrank 0
-hello-8             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 8: Finalizing
-hello-8             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 8:PMIx_Finalize successfully completed
-hello-9             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 9 pid @PID<24>: Running on host @HOST<2> localrank 1
-hello-9             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 9: Finalizing
-hello-9             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 9:PMIx_Finalize successfully completed
-indirect-multi      : Debugger ns @NS<3> rank 0 pid @PID<1>: Running
-indirect-multi      : Debugger URI: @NS<4>;tcp4://@HOST<4>
+daemon-9            : [<host>:PID<?>:@NS<1>@2:9:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 4 entries
+daemon-9            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 8 exec hello
+daemon-9            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 9 exec hello
+daemon-9            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 10 exec hello
+daemon-9            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 11 exec hello
+daemon-9            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+hello-0             : Client ns <host>:PID<?>:@NS<2> rank 0 pid PID<?>: Running on host <host> localrank 0
+hello-0             : Client ns <host>:PID<?>:@NS<2> rank 0: Finalizing
+hello-0             : Client ns <host>:PID<?>:@NS<2> rank 0:PMIx_Finalize successfully completed
+hello-1             : Client ns <host>:PID<?>:@NS<2> rank 1 pid PID<?>: Running on host <host> localrank 1
+hello-1             : Client ns <host>:PID<?>:@NS<2> rank 1: Finalizing
+hello-1             : Client ns <host>:PID<?>:@NS<2> rank 1:PMIx_Finalize successfully completed
+hello-10            : Client ns <host>:PID<?>:@NS<2> rank 10 pid PID<?>: Running on host <host> localrank 2
+hello-10            : Client ns <host>:PID<?>:@NS<2> rank 10: Finalizing
+hello-10            : Client ns <host>:PID<?>:@NS<2> rank 10:PMIx_Finalize successfully completed
+hello-11            : Client ns <host>:PID<?>:@NS<2> rank 11 pid PID<?>: Running on host <host> localrank 3
+hello-11            : Client ns <host>:PID<?>:@NS<2> rank 11: Finalizing
+hello-11            : Client ns <host>:PID<?>:@NS<2> rank 11:PMIx_Finalize successfully completed
+hello-2             : Client ns <host>:PID<?>:@NS<2> rank 2 pid PID<?>: Running on host <host> localrank 2
+hello-2             : Client ns <host>:PID<?>:@NS<2> rank 2: Finalizing
+hello-2             : Client ns <host>:PID<?>:@NS<2> rank 2:PMIx_Finalize successfully completed
+hello-3             : Client ns <host>:PID<?>:@NS<2> rank 3 pid PID<?>: Running on host <host> localrank 3
+hello-3             : Client ns <host>:PID<?>:@NS<2> rank 3: Finalizing
+hello-3             : Client ns <host>:PID<?>:@NS<2> rank 3:PMIx_Finalize successfully completed
+hello-4             : Client ns <host>:PID<?>:@NS<2> rank 4 pid PID<?>: Running on host <host> localrank 0
+hello-4             : Client ns <host>:PID<?>:@NS<2> rank 4: Finalizing
+hello-4             : Client ns <host>:PID<?>:@NS<2> rank 4:PMIx_Finalize successfully completed
+hello-5             : Client ns <host>:PID<?>:@NS<2> rank 5 pid PID<?>: Running on host <host> localrank 1
+hello-5             : Client ns <host>:PID<?>:@NS<2> rank 5: Finalizing
+hello-5             : Client ns <host>:PID<?>:@NS<2> rank 5:PMIx_Finalize successfully completed
+hello-6             : Client ns <host>:PID<?>:@NS<2> rank 6 pid PID<?>: Running on host <host> localrank 2
+hello-6             : Client ns <host>:PID<?>:@NS<2> rank 6: Finalizing
+hello-6             : Client ns <host>:PID<?>:@NS<2> rank 6:PMIx_Finalize successfully completed
+hello-7             : Client ns <host>:PID<?>:@NS<2> rank 7 pid PID<?>: Running on host <host> localrank 3
+hello-7             : Client ns <host>:PID<?>:@NS<2> rank 7: Finalizing
+hello-7             : Client ns <host>:PID<?>:@NS<2> rank 7:PMIx_Finalize successfully completed
+hello-8             : Client ns <host>:PID<?>:@NS<2> rank 8 pid PID<?>: Running on host <host> localrank 0
+hello-8             : Client ns <host>:PID<?>:@NS<2> rank 8: Finalizing
+hello-8             : Client ns <host>:PID<?>:@NS<2> rank 8:PMIx_Finalize successfully completed
+hello-9             : Client ns <host>:PID<?>:@NS<2> rank 9 pid PID<?>: Running on host <host> localrank 1
+hello-9             : Client ns <host>:PID<?>:@NS<2> rank 9: Finalizing
+hello-9             : Client ns <host>:PID<?>:@NS<2> rank 9:PMIx_Finalize successfully completed
+indirect-multi      : Debugger ns @NS<3> rank 0 pid PID<?>: Running
+indirect-multi      : Debugger URI: @NS<4>;tcp4://<host>
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Spawning launcher
@@ -274,11 +242,11 @@ indirect-multi      : Registering READY-FOR-DEBUG handler
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Releasing prterun [@NS<5>,0]
 indirect-multi      : Waiting for application launch
-indirect-multi      : Got READY-FOR-DEBUG event from nspace @HOST<1>:@PID<1>:@NS<6>
-indirect-multi      : Debugger daemon job: @HOST<1>:@PID<1>:@NS<2>
-indirect-multi      : Application has launched: @HOST<1>:@PID<1>:@NS<2>
+indirect-multi      : Got READY-FOR-DEBUG event from nspace <host>:PID<?>:@NS<6>
+indirect-multi      : Debugger daemon job: <host>:PID<?>:@NS<2>
+indirect-multi      : Application has launched: <host>:PID<?>:@NS<2>
 indirect-multi      : Debugger: spawning ./daemon
-indirect-multi      : Debugger nspace: @HOST<1>:@PID<1>:@NS<0>
+indirect-multi      : Debugger nspace: <host>:PID<?>:@NS<0>
 indirect-multi      : Registering handler for debugger termination
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Waiting for IL to terminate

--- a/prrte/debug/indirect-multi.stdout.baseline
+++ b/prrte/debug/indirect-multi.stdout.baseline
@@ -1,99 +1,91 @@
-daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<0> rank 0 pid @PID<0>: Running
+daemon-0            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 0 pid PID<?>: Running
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<0>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] my local rank 0
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-0            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] my local rank 0
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-0            : evhandler_reg_callbk called by daemon as registration callback
 daemon-0            : cbfunc called as daemon callback for PMIx_Query
 daemon-0            : Transferring pmix.qry.lptable
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 5 entries
-daemon-0            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 0 exec hello
-daemon-0            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 1 exec hello
-daemon-0            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 2 exec hello
-daemon-0            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 3 exec hello
-daemon-0            : Proctable[4], namespace @HOST<1>:@PID<1>:@NS<2> rank 4 exec hello
-daemon-0            : [@HOST<1>:@PID<1>:@NS<1>@2:0:@PID<0>] Sending release
-daemon-0            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 5 entries
+daemon-0            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 0 exec hello
+daemon-0            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 1 exec hello
+daemon-0            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 2 exec hello
+daemon-0            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 3 exec hello
+daemon-0            : Proctable[4], namespace <host>:PID<?>:@NS<2> rank 4 exec hello
+daemon-0            : [<host>:PID<?>:@NS<1>@2:0:PID<?>] Sending release
+daemon-0            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
 daemon-0            : release_fn called as daemon callback for event=JOB ENDED
-daemon-0            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-0            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-0            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 0 pid @PID<0>: Finalizing
-daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<2> rank 1 pid @PID<2>: Running
+daemon-0            : DEBUGGER DAEMON NAMESPACE <host>:PID<?>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED <host>:PID<?>:@NS<2>
+daemon-0            : Application namespace <host>:PID<?>:@NS<2> terminated
+daemon-0            : Debugger daemon ns <host>:PID<?>:@NS<0> rank 0 pid PID<?>: Finalizing
+daemon-1            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 1 pid PID<?>: Running
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<2>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] my local rank 0
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-1            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] my local rank 0
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-1            : evhandler_reg_callbk called by daemon as registration callback
 daemon-1            : cbfunc called as daemon callback for PMIx_Query
 daemon-1            : Transferring pmix.qry.lptable
-daemon-1            : [@HOST<1>:@PID<1>:@NS<1>@2:1:@PID<2>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 5 entries
-daemon-1            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 5 exec hello
-daemon-1            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 6 exec hello
-daemon-1            : Proctable[2], namespace @HOST<1>:@PID<1>:@NS<2> rank 7 exec hello
-daemon-1            : Proctable[3], namespace @HOST<1>:@PID<1>:@NS<2> rank 8 exec hello
-daemon-1            : Proctable[4], namespace @HOST<1>:@PID<1>:@NS<2> rank 9 exec hello
-daemon-1            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-1            : release_fn called as daemon callback for event=JOB ENDED
-daemon-1            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-1            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-1            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 1 pid @PID<2>: Finalizing
-daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> on host @HOST<3> rank 2 pid @PID<3>: Running
+daemon-1            : [<host>:PID<?>:@NS<1>@2:1:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 5 entries
+daemon-1            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 5 exec hello
+daemon-1            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 6 exec hello
+daemon-1            : Proctable[2], namespace <host>:PID<?>:@NS<2> rank 7 exec hello
+daemon-1            : Proctable[3], namespace <host>:PID<?>:@NS<2> rank 8 exec hello
+daemon-1            : Proctable[4], namespace <host>:PID<?>:@NS<2> rank 9 exec hello
+daemon-1            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+daemon-2            : Debugger daemon ns <host>:PID<?>:@NS<0> on host <host> rank 2 pid PID<?>: Running
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:-2:@PID<3>] PMIX_DEBUG_JOB is '@HOST<1>:@PID<1>:@NS<2>'
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<3>] Debugging '@HOST<1>:@PID<1>:@NS<2>'
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<3>] my local rank 0
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<3>] registering for termination of '@HOST<1>:@PID<1>:@NS<2>'
+daemon-2            : [<host>:PID<?>:@NS<1>@2:-2:PID<?>] PMIX_DEBUG_JOB is '<host>:PID<?>:@NS<2>'
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] Debugging '<host>:PID<?>:@NS<2>'
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] my local rank 0
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] registering for termination of '<host>:PID<?>:@NS<2>'
 daemon-2            : evhandler_reg_callbk called by daemon as registration callback
 daemon-2            : cbfunc called as daemon callback for PMIx_Query
 daemon-2            : Transferring pmix.qry.lptable
-daemon-2            : [@HOST<1>:@PID<1>:@NS<1>@2:2:@PID<3>] Local proctable received for nspace '@HOST<1>:@PID<1>:@NS<2>' has 2 entries
-daemon-2            : Proctable[0], namespace @HOST<1>:@PID<1>:@NS<2> rank 10 exec hello
-daemon-2            : Proctable[1], namespace @HOST<1>:@PID<1>:@NS<2> rank 11 exec hello
-daemon-2            : Waiting for application namespace @HOST<1>:@PID<1>:@NS<2> to terminate
-daemon-2            : release_fn called as daemon callback for event=JOB ENDED
-daemon-2            : DEBUGGER DAEMON NAMESPACE @HOST<1>:@PID<1>:@NS<0> NOTIFIED THAT JOB TERMINATED - AFFECTED @HOST<1>:@PID<1>:@NS<2>
-daemon-2            : Application namespace @HOST<1>:@PID<1>:@NS<2> terminated
-daemon-2            : Debugger daemon ns @HOST<1>:@PID<1>:@NS<0> rank 2 pid @PID<3>: Finalizing
-hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0 pid @PID<4>: Running on host @HOST<0> localrank 0
-hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0: Finalizing
-hello-0             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 0:PMIx_Finalize successfully completed
-hello-1             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 1 pid @PID<5>: Running on host @HOST<0> localrank 1
-hello-1             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 1: Finalizing
-hello-1             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 1:PMIx_Finalize successfully completed
-hello-10            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 10 pid @PID<6>: Running on host @HOST<3> localrank 0
-hello-10            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 10: Finalizing
-hello-10            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 10:PMIx_Finalize successfully completed
-hello-11            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 11 pid @PID<7>: Running on host @HOST<3> localrank 1
-hello-11            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 11: Finalizing
-hello-11            : Client ns @HOST<1>:@PID<1>:@NS<2> rank 11:PMIx_Finalize successfully completed
-hello-2             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 2 pid @PID<8>: Running on host @HOST<0> localrank 2
-hello-2             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 2: Finalizing
-hello-2             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 2:PMIx_Finalize successfully completed
-hello-3             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 3 pid @PID<9>: Running on host @HOST<0> localrank 3
-hello-3             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 3: Finalizing
-hello-3             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 3:PMIx_Finalize successfully completed
-hello-4             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 4 pid @PID<10>: Running on host @HOST<0> localrank 4
-hello-4             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 4: Finalizing
-hello-4             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 4:PMIx_Finalize successfully completed
-hello-5             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 5 pid @PID<11>: Running on host @HOST<2> localrank 0
-hello-5             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 5: Finalizing
-hello-5             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 5:PMIx_Finalize successfully completed
-hello-6             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 6 pid @PID<12>: Running on host @HOST<2> localrank 1
-hello-6             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 6: Finalizing
-hello-6             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 6:PMIx_Finalize successfully completed
-hello-7             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 7 pid @PID<13>: Running on host @HOST<2> localrank 2
-hello-7             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 7: Finalizing
-hello-7             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 7:PMIx_Finalize successfully completed
-hello-8             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 8 pid @PID<14>: Running on host @HOST<2> localrank 3
-hello-8             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 8: Finalizing
-hello-8             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 8:PMIx_Finalize successfully completed
-hello-9             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 9 pid @PID<15>: Running on host @HOST<2> localrank 4
-hello-9             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 9: Finalizing
-hello-9             : Client ns @HOST<1>:@PID<1>:@NS<2> rank 9:PMIx_Finalize successfully completed
-indirect-multi      : Debugger ns @NS<3> rank 0 pid @PID<1>: Running
-indirect-multi      : Debugger URI: @NS<4>;tcp4://@HOST<4>
+daemon-2            : [<host>:PID<?>:@NS<1>@2:2:PID<?>] Local proctable received for nspace '<host>:PID<?>:@NS<2>' has 2 entries
+daemon-2            : Proctable[0], namespace <host>:PID<?>:@NS<2> rank 10 exec hello
+daemon-2            : Proctable[1], namespace <host>:PID<?>:@NS<2> rank 11 exec hello
+daemon-2            : Waiting for application namespace <host>:PID<?>:@NS<2> to terminate
+hello-0             : Client ns <host>:PID<?>:@NS<2> rank 0 pid PID<?>: Running on host <host> localrank 0
+hello-0             : Client ns <host>:PID<?>:@NS<2> rank 0: Finalizing
+hello-0             : Client ns <host>:PID<?>:@NS<2> rank 0:PMIx_Finalize successfully completed
+hello-1             : Client ns <host>:PID<?>:@NS<2> rank 1 pid PID<?>: Running on host <host> localrank 1
+hello-1             : Client ns <host>:PID<?>:@NS<2> rank 1: Finalizing
+hello-1             : Client ns <host>:PID<?>:@NS<2> rank 1:PMIx_Finalize successfully completed
+hello-10            : Client ns <host>:PID<?>:@NS<2> rank 10 pid PID<?>: Running on host <host> localrank 0
+hello-10            : Client ns <host>:PID<?>:@NS<2> rank 10: Finalizing
+hello-10            : Client ns <host>:PID<?>:@NS<2> rank 10:PMIx_Finalize successfully completed
+hello-11            : Client ns <host>:PID<?>:@NS<2> rank 11 pid PID<?>: Running on host <host> localrank 1
+hello-11            : Client ns <host>:PID<?>:@NS<2> rank 11: Finalizing
+hello-11            : Client ns <host>:PID<?>:@NS<2> rank 11:PMIx_Finalize successfully completed
+hello-2             : Client ns <host>:PID<?>:@NS<2> rank 2 pid PID<?>: Running on host <host> localrank 2
+hello-2             : Client ns <host>:PID<?>:@NS<2> rank 2: Finalizing
+hello-2             : Client ns <host>:PID<?>:@NS<2> rank 2:PMIx_Finalize successfully completed
+hello-3             : Client ns <host>:PID<?>:@NS<2> rank 3 pid PID<?>: Running on host <host> localrank 3
+hello-3             : Client ns <host>:PID<?>:@NS<2> rank 3: Finalizing
+hello-3             : Client ns <host>:PID<?>:@NS<2> rank 3:PMIx_Finalize successfully completed
+hello-4             : Client ns <host>:PID<?>:@NS<2> rank 4 pid PID<?>: Running on host <host> localrank 4
+hello-4             : Client ns <host>:PID<?>:@NS<2> rank 4: Finalizing
+hello-4             : Client ns <host>:PID<?>:@NS<2> rank 4:PMIx_Finalize successfully completed
+hello-5             : Client ns <host>:PID<?>:@NS<2> rank 5 pid PID<?>: Running on host <host> localrank 0
+hello-5             : Client ns <host>:PID<?>:@NS<2> rank 5: Finalizing
+hello-5             : Client ns <host>:PID<?>:@NS<2> rank 5:PMIx_Finalize successfully completed
+hello-6             : Client ns <host>:PID<?>:@NS<2> rank 6 pid PID<?>: Running on host <host> localrank 1
+hello-6             : Client ns <host>:PID<?>:@NS<2> rank 6: Finalizing
+hello-6             : Client ns <host>:PID<?>:@NS<2> rank 6:PMIx_Finalize successfully completed
+hello-7             : Client ns <host>:PID<?>:@NS<2> rank 7 pid PID<?>: Running on host <host> localrank 2
+hello-7             : Client ns <host>:PID<?>:@NS<2> rank 7: Finalizing
+hello-7             : Client ns <host>:PID<?>:@NS<2> rank 7:PMIx_Finalize successfully completed
+hello-8             : Client ns <host>:PID<?>:@NS<2> rank 8 pid PID<?>: Running on host <host> localrank 3
+hello-8             : Client ns <host>:PID<?>:@NS<2> rank 8: Finalizing
+hello-8             : Client ns <host>:PID<?>:@NS<2> rank 8:PMIx_Finalize successfully completed
+hello-9             : Client ns <host>:PID<?>:@NS<2> rank 9 pid PID<?>: Running on host <host> localrank 4
+hello-9             : Client ns <host>:PID<?>:@NS<2> rank 9: Finalizing
+hello-9             : Client ns <host>:PID<?>:@NS<2> rank 9:PMIx_Finalize successfully completed
+indirect-multi      : Debugger ns @NS<3> rank 0 pid PID<?>: Running
+indirect-multi      : Debugger URI: @NS<4>;tcp4://<host>
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Spawning launcher
@@ -103,11 +95,11 @@ indirect-multi      : Registering READY-FOR-DEBUG handler
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Releasing prterun [@NS<5>,0]
 indirect-multi      : Waiting for application launch
-indirect-multi      : Got READY-FOR-DEBUG event from nspace @HOST<1>:@PID<1>:@NS<6>
-indirect-multi      : Debugger daemon job: @HOST<1>:@PID<1>:@NS<2>
-indirect-multi      : Application has launched: @HOST<1>:@PID<1>:@NS<2>
+indirect-multi      : Got READY-FOR-DEBUG event from nspace <host>:PID<?>:@NS<6>
+indirect-multi      : Debugger daemon job: <host>:PID<?>:@NS<2>
+indirect-multi      : Application has launched: <host>:PID<?>:@NS<2>
 indirect-multi      : Debugger: spawning ./daemon
-indirect-multi      : Debugger nspace: @HOST<1>:@PID<1>:@NS<0>
+indirect-multi      : Debugger nspace: <host>:PID<?>:@NS<0>
 indirect-multi      : Registering handler for debugger termination
 indirect-multi      : evhandler_reg_callbk called with status SUCCESS
 indirect-multi      : Waiting for IL to terminate

--- a/prrte/debug/run.sh
+++ b/prrte/debug/run.sh
@@ -27,6 +27,5 @@ fi
 
 # Wrapper script used by CI framework to invoke test cases in this directory
 
-# Temporarily disable debugger CI tests
-#${_python} ./cirun.py
-exit 0
+${_python} ./cirun.py
+exit $?

--- a/prrte/debug/run.sh
+++ b/prrte/debug/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Baselines assume exactly 3 nodes
+_required_num_nodes=3
+
 _python=""
 
 # Find all python* binaries
@@ -25,7 +28,29 @@ if [[ $_python == "" ]] ; then
     exit 1
 fi
 
+# Sanity checking on number of nodes
+if [ "x" = "x$CI_NUM_NODES" ] ; then
+    echo "Error: CI_NUM_NODES must be provided"
+    exit 2
+fi
+if [ "x" = "x$CI_HOSTFILE" ] ; then
+    echo "Error: A CI_HOSTFILE must be provided with 3 nodes"
+    exit 3
+fi
+if [[ "$CI_NUM_NODES" -lt "$_required_num_nodes" ]] ; then
+    echo "Error: CI_NUM_NODES must be greater than or equal to $_required_num_nodes"
+    exit 2
+fi
+
+export CI_NUM_NODES=$_required_num_nodes
+
+CI_HOSTFILE_DEBUG=${CI_HOSTFILE}.debug
+head -n $CI_NUM_NODES $CI_HOSTFILE > $CI_HOSTFILE_DEBUG
+export CI_HOSTFILE=$CI_HOSTFILE_DEBUG
+
 # Wrapper script used by CI framework to invoke test cases in this directory
 
 ${_python} ./cirun.py
-exit $?
+_rtn=$?
+rm $CI_HOSTFILE_DEBUG
+exit $_rtn


### PR DESCRIPTION
The PRRTE tools CI tests were failing in multinode tests because the baseline file did not match the current output for the testcases.

The testcases attempted to solve the problem of running the testcases on different clusters by rewriting the hostnames with strings HOST&LT;1&GT;, HOST&LT;2&GT; etc which were assigned based on the order of appearance of hostnames in the output. The PIDs for daemons and application processes were handled similarly.

This did not work with tests running on multiple nodes since the order of launch for tool daemons and application processes across nodes was indeterminate. This could also happen on single nodes, but the ordering seemed to be more stable and not causing failures.

The tcfilter program that rewirtes the testcase output was modiifed to replace PID and hostname in the output file with constant strings. This requires new baseline files as well.

This is not ideal, but works. Attempting to build the table mapping hostnames to unique strings using the hostfile as input worked but was quite fragile.

Fixes #88