### PR TITLE
Only run special builds test against PRRTE v2.0 branch

### DIFF
--- a/ci-builds/prrte/02-build-w-pmix-v4.0.sh
+++ b/ci-builds/prrte/02-build-w-pmix-v4.0.sh
@@ -33,7 +33,12 @@ cd $_BUILD_DIR
 #--------------------------------
 # PMIx Build
 #--------------------------------
-git clone -b v4.1 https://github.com/openpmix/openpmix.git
+if [ -n "$PR_TARGET_BRANCH" ] &&  [ "$PR_TARGET_BRANCH" == "v2.0" ] ; then
+  git clone -b v4.1 https://github.com/openpmix/openpmix.git
+else
+  # no need to do another build as we have tested against pmix master elsewhere
+  exit 0
+fi
 cd openpmix
 
 #--------------------------------


### PR DESCRIPTION
PRRTE master is no longer necessarily tied to the PMIx v4.1 release

Signed-off-by: Ralph Castain <rhc@pmix.org>