### PR TITLE
Specify mapping/ranking options when starting tests

### DIFF
--- a/prrte/debug/run.py
+++ b/prrte/debug/run.py
@@ -239,6 +239,7 @@ def run(selected, testCases):
             if ((testCase[1] & MULTINODE_TEST) != 0):
                 attachProcess = Popen(["prterun", "--report-uri", "+",
                                       "--hostfile", hostFile,
+                                      "--map-by", "node", "--rank-by", "slot",
                                       "-n", str(numNodes * 2), "hello",
                                       str(int(ATTACH_WAITTIME))], 
                                       stdout=PIPE, stderr=STDOUT)


### PR DESCRIPTION
For the attach tests, we need to specify we want them
mapped by-node and ranked by-slot to ensure we get
consistent output. Otherwise, you are depending upon
the default map/rank settings, which can change.

Signed-off-by: Ralph Castain <rhc@pmix.org>