### PR TITLE
XVersion CI: Remove ppc64le build

### DIFF
--- a/.github/workflows/update-xversion.yml
+++ b/.github/workflows/update-xversion.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     # Run once a week on Sunday (UTC)
     - cron: '0 1 * * 0'
-#  push:
-#    branches:
-#      - 'master'
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -62,7 +59,8 @@ jobs:
           # See the QEMU link above for supported architectures
           # Note that non-amd64 will take a long time due to QEMU virtualization
           # but they do seem to run in parallel.
-          platforms: linux/amd64,linux/ppc64le
+          #platforms: linux/amd64,linux/ppc64le
+          platforms: linux/amd64
           push: true
           tags: ${{ env.IMAGE_NAME }}:latest
           build-args: BUILD_TIMESTAMP='${{ steps.date.outputs.date }}'


### PR DESCRIPTION
 * GitHub Action limits to 6 hours of execution and the QEMU builder can get
   stuck/slow and reach that limit. Removing the ppc64le build for now.

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>