### PR TITLE
prrte/dmodex: Disable this test.

### DIFF
--- a/prrte/.ci-tests
+++ b/prrte/.ci-tests
@@ -1,7 +1,9 @@
 # Start with the basics
 hello_world
 # Test more than PMIx_Init/finalize with dmodex.
-dmodex
+# Re-enable once this stabilizes.
+# See issue: https://github.com/openpmix/prrte/issues/1243
+#dmodex
 # 'prun' all in one wrapper like some downstream projects use
 prun-wrapper
 # MPIR Shim: https://github.com/openpmix/mpir-to-pmix-guide


### PR DESCRIPTION
There are intermittent CI failures that need resolving.
See prrte issue: https://github.com/openpmix/prrte/issues/1243

Will revert/put this test back once the above is fixed/closed.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>