### PR TITLE
Update the dmodex test output for clarity

### DIFF
--- a/prrte/dmodex/dmodex.c
+++ b/prrte/dmodex/dmodex.c
@@ -50,6 +50,8 @@ int main(int argc, char **argv)
     char **peers;
     pmix_rank_t *locals = NULL;
     uint8_t j;
+    pmix_info_t timeout;
+    int tlimit = 10;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 
@@ -143,6 +145,7 @@ int main(int argc, char **argv)
     PMIX_ARGV_FREE(peers);
 
     snprintf(proc.nspace, PMIX_MAX_NSLEN, "%s",  myproc.nspace);
+    PMIX_INFO_LOAD(&timeout, PMIX_TIMEOUT, &tlimit, PMIX_INT);
     /* get the committed data - ask for someone who doesn't exist as well */
     for (n = 0; n < nprocs; n++) {
         if (all_local) {
@@ -160,14 +163,14 @@ int main(int argc, char **argv)
         proc.rank = n;
         if (local) {
             (void)snprintf(tmp, 1024, "%s-%d-local", proc.nspace, n);
-            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
-                fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, n,
-                        tmp, rc);
+            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, &timeout, 1, &val))) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %s\n", myproc.nspace, n,
+                        tmp, PMIx_Error_string(rc));
                 goto done;
             }
             if (PMIX_UINT64 != val->type) {
-                fprintf(stderr, "%s:%d: PMIx_Get Key %s returned wrong type: %d\n", myproc.nspace,
-                        myproc.rank, tmp, val->type);
+                fprintf(stderr, "%s:%d: PMIx_Get Key %s returned wrong type: %s\n", myproc.nspace,
+                        myproc.rank, tmp, PMIx_Data_type_string(val->type));
                 PMIX_VALUE_RELEASE(val);
                 goto done;
             }
@@ -182,14 +185,14 @@ int main(int argc, char **argv)
             PMIX_VALUE_RELEASE(val);
         } else {
             (void)snprintf(tmp, 1024, "%s-%d-remote", myproc.nspace, n);
-            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
-                fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, n,
-                        tmp, rc);
+            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, &timeout, 1, &val))) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %s\n", myproc.nspace, n,
+                        tmp, PMIx_Error_string(rc));
                 goto done;
             }
             if (PMIX_STRING != val->type) {
-                fprintf(stderr, "%s:%d: PMIx_Get Key %s returned wrong type: %d\n", myproc.nspace,
-                        myproc.rank, tmp, val->type);
+                fprintf(stderr, "%s:%d: PMIx_Get Key %s returned wrong type: %s\n", myproc.nspace,
+                        myproc.rank, tmp, PMIx_Data_type_string(val->type));
                 PMIX_VALUE_RELEASE(val);
                 goto done;
             }
@@ -205,14 +208,14 @@ int main(int argc, char **argv)
         }
         /* if this isn't us, then get the ghex key */
         if (n != myproc.rank) {
-            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, "ghex", NULL, 0, &val))) {
-                fprintf(stderr, "Client ns %s rank %d: PMIx_Get ghex failed: %d\n", myproc.nspace,
-                        n, rc);
+            if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, "ghex", &timeout, 1, &val))) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Get ghex failed: %s\n", myproc.nspace,
+                        n, PMIx_Error_string(rc));
                 goto done;
             }
             if (PMIX_BYTE_OBJECT != val->type) {
-                fprintf(stderr, "%s:%d: PMIx_Get ghex returned wrong type: %d\n", myproc.nspace,
-                        myproc.rank, val->type);
+                fprintf(stderr, "%s:%d: PMIx_Get ghex returned wrong type: %s\n", myproc.nspace,
+                        myproc.rank, PMIx_Data_type_string(val->type));
                 PMIX_VALUE_RELEASE(val);
                 goto done;
             }


### PR DESCRIPTION
Print the error and type strings instead of the numerical value.

Signed-off-by: Ralph Castain <rhc@pmix.org>