### PR TITLE
Remove dependency on internal PMIx header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ prrte/debug/direct.stderr
 prrte/debug/direct.stdout
 prrte/manystress/sleeper
 prrte/manystress/output.txt
+prrte/dmodex/dmodex
+prrte/dmodex/output.txt

--- a/prrte/dmodex/dmodex.c
+++ b/prrte/dmodex/dmodex.c
@@ -25,15 +25,13 @@
  *
  */
 
-#include "examples.h"
-#include "src/include/pmix_config.h"
-#include "../include/pmix.h"
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
+#include <pmix.h>
+
+#include "examples.h"
 
 static uint32_t nprocs;
 static pmix_proc_t myproc;

--- a/prrte/dmodex/dmodex.c
+++ b/prrte/dmodex/dmodex.c
@@ -152,7 +152,11 @@ int main(int argc, char **argv)
     PMIX_INFO_LOAD(&timeout, PMIX_TIMEOUT, &tlimit, PMIX_INT);
     /* get the committed data - ask for someone who doesn't exist as well */
     for (n = 0; n < nprocs; n++) {
-        if (all_local) {
+        if (n == myproc.rank) {
+            /* local peers doesn't include us, so check for
+             * ourselves separately */
+            local = true;
+        } else if (all_local) {
             local = true;
         } else {
             local = false;


### PR DESCRIPTION
Only need the public APIs, so just use that header. Also
update the gitignore's for the new executable and output
files

Signed-off-by: Ralph Castain <rhc@pmix.org>