### PR TITLE
Move the dmodex test to last.

### DIFF
--- a/prrte/.ci-tests
+++ b/prrte/.ci-tests
@@ -1,7 +1,5 @@
 # Start with the basics
 hello_world
-# Test more than PMIx_Init/finalize with dmodex.
-dmodex
 # 'prun' all in one wrapper like some downstream projects use
 prun-wrapper
 # MPIR Shim: https://github.com/openpmix/mpir-to-pmix-guide
@@ -12,3 +10,5 @@ cycle
 debug
 # Add the Many Stress Test case
 #manystress
+# Test more than PMIx_Init/finalize with dmodex.
+dmodex

--- a/prrte/dmodex/run.sh
+++ b/prrte/dmodex/run.sh
@@ -13,10 +13,11 @@ _shutdown()
     # Cleanup DVM
     # ---------------------------------------
     pterm
-
+    cat $CI_HOSTFILE | xargs -L1 -I '{}'  ssh {} rm -rf /tmp/prte.*
     exit $FINAL_RTN
 }
 
+cat $CI_HOSTFILE | xargs -L1 -I '{}'  ssh {} rm -rf /tmp/prte.*
 
 # ---------------------------------------
 # Run the test - Dmodex (PMIx)


### PR DESCRIPTION
This way with the intermittent failures, it will give the other
tests a chance to run.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>