### PR TITLE
Force submodule update, just in case

### DIFF
--- a/ci-builds/run-all-pmix.sh
+++ b/ci-builds/run-all-pmix.sh
@@ -15,6 +15,13 @@ if [ ! -d ${_PMIX_CHECKOUT} ] ; then
 fi
 
 #--------------------------------
+# Double check that the submodule pointers are updated
+#--------------------------------
+cd ${_PMIX_CHECKOUT}
+git submodule update --init --recursive
+cd -
+
+#--------------------------------
 # All of the builds sorted
 # Builds must start with at least a 2 digit number (`07`)
 #--------------------------------

--- a/ci-builds/run-all-prrte.sh
+++ b/ci-builds/run-all-prrte.sh
@@ -29,6 +29,17 @@ if [ ! -d ${_PRRTE_CHECKOUT} ] ; then
 fi
 
 #--------------------------------
+# Double check that the submodule pointers are updated
+#--------------------------------
+cd ${_PMIX_CHECKOUT}
+git submodule update --init --recursive
+cd -
+
+cd ${_PRRTE_CHECKOUT}
+git submodule update --init --recursive
+cd -
+
+#--------------------------------
 # All of the builds sorted
 # Builds must start with at least a 2 digit number (`07`)
 #--------------------------------

--- a/crossversion/xversion.py
+++ b/crossversion/xversion.py
@@ -164,6 +164,14 @@ def build_tree(bld, logfile=None):
 
     print("============ PMIx Build: "+bld.branch+" : "+os.getcwd())
 
+    print("============ PMIx Build: "+bld.branch+" : Submodule update")
+    ret = subprocess.call(["git", "submodule", "update", "--init", "--recursive"],
+                          stdout=logfile, stderr=logfile, shell=False)
+    if 0 != ret:
+        print("Error: \"git submodule update --init --recursive\" failed. Possible network issue.");
+        os.chdir(orig_dir)
+        return ret
+
     print("============ PMIx Build: "+bld.branch+" : Autogen")
     if os.path.exists("autogen.pl") is True:
         ret = subprocess.call(["./autogen.pl"], stdout=logfile, stderr=logfile, shell=False)


### PR DESCRIPTION
This should get the special builds and cross-version tests running with the submodule PRs. It forces a `git submodule update --init --recursive` before calling `autogen.pl`. Normally this shouldn't be needed, but it doesn't hurt to do.