### PR TITLE
Extend the timeouts for the PRRTE tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ prrte/hello_world/output.txt
 prrte/hello_world/output-hn.txt
 prrte/cycle/output.txt
 prrte/cycle/init_finalize_pmix
+prrte/cycle/multi_init_finalize_pmix
 prrte/cycle/dvm.uri
 prrte/prun-wrapper/output*.txt
 prrte/prun-wrapper/bin

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # pmix-tests
-Test harness for PMIx reference implementation
+Test harness for PMIx reference implementation (OpenPMIx)

--- a/prrte/cycle/build.sh
+++ b/prrte/cycle/build.sh
@@ -17,7 +17,8 @@ echo ${PCC} --showme
 set -e
 
 echo "=========================="
-echo "Building PMIx Hello World"
+echo "Building PMIx cycle tests"
 echo "=========================="
 
 ${PCC} init_finalize_pmix.c -o init_finalize_pmix
+${PCC} multi_init_finalize_pmix.c -o multi_init_finalize_pmix

--- a/prrte/cycle/multi_init_finalize_pmix.c
+++ b/prrte/cycle/multi_init_finalize_pmix.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019      IBM, Inc.  All rights reserved.
+ * Copyright (c) 2023      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <pmix.h>
+
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pid_t pid;
+    char hostname[1024];
+    pmix_proc_t myproc;
+    int n, niters = 2;
+    bool dofence = true;
+
+    pid = getpid();
+    gethostname(hostname, 1024);
+
+    for (n=1; n < argc; n++) {
+        if (0 == strncasecmp(argv[n], "--iter", 6)) { // accept iter or iters
+            niters = strtoul(argv[n+1], NULL, 10);
+            ++n; // skip over argument
+        } else if (0 == strcasecmp(argv[n], "--no-fence")) {
+            dofence = false;
+        }
+    }
+
+    for (n=0; n < niters; n++) {
+        if( PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0)) ) {
+            fprintf(stderr, "ERROR: PMIx_Init failed (%lu on %s): %d\n",
+                    (unsigned long)pid, hostname, rc);
+            exit(1);
+        }
+
+        if (dofence) {
+            rc = PMIx_Fence(NULL, 0, NULL, 0);
+            if (PMIX_SUCCESS != rc) {
+                fprintf(stderr, "ERROR: PMIx_Fence failed (%lu on %s): %d\n",
+                        (unsigned long)pid, hostname, rc);
+                exit(1);
+            }
+        }
+
+        if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+            fprintf(stderr, "ERROR: PMIx_Finalize failed (%lu on %s): %d (%s)\n",
+                    (unsigned long)pid, hostname, rc, PMIx_Error_string(rc));
+            exit(1);
+        }
+    }
+
+    fflush(stderr);
+    return(0);
+}

--- a/prrte/cycle/run.sh
+++ b/prrte/cycle/run.sh
@@ -85,7 +85,7 @@ prte --no-ready-msg --report-uri dvm.uri $hostarg &
 # ---------------------------------------
 # Run the test - init_finalize
 # ---------------------------------------
-_CMD="prun --dvm-uri file:dvm.uri --num-connect-retries 1000 ./init_finalize_pmix"
+_CMD="prun --dvm-uri file:dvm.uri --num-connect-retries 1000 -n 4 --map-by :oversubscribe ./init_finalize_pmix"
 echo ""
 echo "======================="
 echo "Running init_finalize_pmix: $_CMD"

--- a/prrte/cycle/run.sh
+++ b/prrte/cycle/run.sh
@@ -125,4 +125,56 @@ if [ $FINAL_RTN == 0 ] ; then
     echo "Success"
 fi
 
+pterm --dvm-uri file:dvm.uri
+
+
+rm -f dvm.uri
+echo "======================="
+echo "Starting DVM: prte --no-ready-msg --report-uri dvm.uri $hostarg &"
+echo "======================="
+prte --no-ready-msg --report-uri dvm.uri $hostarg &
+
+# ---------------------------------------
+# Run the test - init_finalize
+# ---------------------------------------
+_CMD="prun --dvm-uri file:dvm.uri --num-connect-retries 1000 -n 4 --map-by :oversubscribe ./multi_init_finalize_pmix"
+echo ""
+echo "======================="
+echo "Running multi_init_finalize_pmix: $_CMD"
+echo "======================="
+
+rm -f output.txt ; touch output.txt
+for n in $(seq 1 $NUM_ITERS) ; do
+    echo -e "--------------------- Execution (init/finalize): $n"
+    $_CMD 2>&1 | tee -a output.txt
+    st=${PIPESTATUS[0]}
+    if [ $st -ne 0 ] ; then
+        echo "ERROR: prun failed with $st"
+        FINAL_RTN=3
+        _shutdown
+    fi
+done
+
+echo "---- Done"
+# ---------------------------------------
+# Verify the results
+# ---------------------------------------
+ERRORS=`grep ERROR output.txt | wc -l`
+if [[ $ERRORS -ne 0 ]] ; then
+    echo "ERROR: Error string detected in the output"
+    FINAL_RTN=1
+    _shutdown
+fi
+
+LINES=`wc -l output.txt | awk '{print $1}'`
+if [[ $LINES -ne 0 ]] ; then
+    echo "ERROR: Incorrect number of lines of output. Expected 0. Actual $LINES"
+    FINAL_RTN=2
+    _shutdown
+fi
+
+if [ $FINAL_RTN == 0 ] ; then
+    echo "Success"
+fi
+
 _shutdown

--- a/prrte/debug/run.py
+++ b/prrte/debug/run.py
@@ -137,9 +137,9 @@ def run(selected, testCases):
     global testcases, failures, failedTests
     prteProcess = None
     rc = 0
-    testcaseTimeout = 60.0
-    daemonDelay = 5.0
-    waitTimeout = 5.0
+    testcaseTimeout = 120.0
+    daemonDelay = 10.0
+    waitTimeout = 10.0
     hostFile = "./hostfile"
     try:
         hostFile = environ["CI_HOSTFILE"]


### PR DESCRIPTION
[Extend the timeouts for the PRRTE tests](https://github.com/openpmix/pmix-tests/pull/152/commits/9e90991110cd0afcfde5ebf6d933dda93088d59d)

Try to make debug more reliable by upping
the timeout values.

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Specify four procs for init/finalize test](https://github.com/openpmix/pmix-tests/pull/152/commits/7a9507f3db44a6adc78862790d0a8815d681c06e)

Ensure it is more than one

Signed-off-by: Ralph Castain <rhc@pmix.org>