### PR TITLE
Use an improved comparison function for "debug" tests

### DIFF
--- a/prrte/debug/compare.py
+++ b/prrte/debug/compare.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import sys
+
+def main():
+    matrix1 = []
+    missing = []
+    extras = []
+    exitcode = 0
+
+    if (3 != len(sys.argv)):
+        print("Usage: compare <testout> <baseline>")
+        sys.exit(1)
+
+    # open the first file
+    file = open(sys.argv[1], "r")
+    for line in file:
+        # see if we already have this line
+        found = False
+        for l2 in matrix1:
+            if (l2['line'] == line):
+                l2['num'] = l2['num'] + 1
+                found = True
+                break
+        if not found:
+            matrix1.append({'line': line, 'num': 1, 'found': 0})
+    file.close()
+
+    # open in second file
+    file = open(sys.argv[2], "r")
+    for line in file:
+        found = False
+        for l in matrix1:
+            if (l['line'] == line):
+                l['found'] = l['found'] + 1
+                found = True
+        if not found:
+            missing.append(line)
+    file.close()
+
+    if (0 < len(missing)):
+        exitcode = 1
+        print("LINES MISSING FROM", sys.argv[1])
+        for l in missing:
+            print(l)
+
+    # check for mismatched numbers of occurrences
+    # of lines
+    for l in matrix1:
+        if (l['found'] != l['num']):
+            extras.append(l)
+    
+    if (0 < len(extras)):
+        exitcode = 1
+        print("MISMATCHED OCCURRENCES - COMPARING SOURCE", sys.argv[1], "TO BASELINE", sys.argv[2])
+        for l in extras:
+            print("SOURCE", l['num'], " BASELINE:", l['found'], " LINE:", l['line'])
+
+    sys.exit(exitcode)
+    
+if __name__ == '__main__':
+    main()

--- a/prrte/debug/run.py
+++ b/prrte/debug/run.py
@@ -405,15 +405,6 @@ def run(selected, testCases):
               # Get the testcase stdout and stderr output, split that output
               # into '\n'-delimited newlines, and sort the resulting text
               # arrays by the line prefix tag
-              #
-              # Sorting by line prefix tag eliminates false failures due to
-              # difference in ordering of testcase output with differing
-              # timing of execution by individual tasks.
-              #
-              # This eliminates the possibility of detecting problems caused
-              # by differing timing of interactions between processes, but
-              # that kind of testing is probably outside the scope of 
-              # simple CI testing.
             stdoutText = sorted(stdoutText.splitlines(keepends=True))
             stderrText = sorted(stderrText.splitlines(keepends=True))
 
@@ -445,8 +436,8 @@ def run(selected, testCases):
             stderrFilter.wait(waitTimeout)
 
               # Compare stdout and stderr output to corresponding baselines
-            diffProcess = Popen(["/bin/diff", stdoutPath + ".baseline",
-                                 stdoutPath])
+            diffProcess = Popen(["./compare.py", stdoutPath,
+                                 stdoutPath + ".baseline"])
             diffProcess.wait(waitTimeout)
             if (diffProcess.returncode != 0):
                 log("ERROR: testcase ", testCase[0],
@@ -456,8 +447,8 @@ def run(selected, testCases):
                 rc = 1
                 continue
 
-            diffProcess = Popen(["/bin/diff", stderrPath + ".baseline",
-                                 stderrPath])
+            diffProcess = Popen(["./compare.py", stderrPath,
+                                 stderrPath  + ".baseline"])
             diffProcess.wait(waitTimeout)
             if (diffProcess.returncode != 0):
                 log("ERROR: testcase ", testCase[0],


### PR DESCRIPTION
The current method does a simple "diff", which means that differences in line order appear as failures. Since output is being redirected, there is no
guarantee of ordering. We have been dealing with
ordering-related errors for some time now, resolving them by simply retrying until the order comes out
"right".

Switch to a custom comparison program that checks
to see that all lines appear in the new output
when compared to the baseline, and that they
appear the expected number of times. Output
any outliers and return an error status.

Signed-off-by: Ralph Castain <rhc@pmix.org>