### PR TITLE
Compare PMIx Standard and OpenPMIx

### DIFF
--- a/.github/workflows/pmix-standard.yaml
+++ b/.github/workflows/pmix-standard.yaml
@@ -1,0 +1,39 @@
+name: Compare PMIx Standard and OpenPMIx
+
+on:
+  schedule:
+    # Run once a week on Sunday (UTC)
+    - cron: '0 1 * * 0'
+  push:
+    # Run whenever pmix-tests master branch changes
+    branches:
+      - master
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: jjhursey/pmix-standard
+
+jobs:
+  check-std-v4:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Check out the code
+        uses: actions/checkout@v1
+      # Run the container tester
+      - name: Compare with v4
+        run: docker run --rm -v ${GITHUB_WORKSPACE}:/home/pmixer/pmix-tests ${{ env.IMAGE_NAME }}:latest /bin/bash -c "cd /tmp && /home/pmixer/pmix-tests/check-standard/bin/run-v4-check.sh"
+        shell: bash
+
+  check-std-v5:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Check out the code
+        uses: actions/checkout@v1
+      # Run the container tester
+      - name: Compare with v5
+        run: docker run --rm -v ${GITHUB_WORKSPACE}:/home/pmixer/pmix-tests ${{ env.IMAGE_NAME }}:latest /bin/bash -c "cd /tmp && /home/pmixer/pmix-tests/check-standard/bin/run-v5-check.sh"
+        shell: bash

--- a/check-standard/README.md
+++ b/check-standard/README.md
@@ -1,0 +1,98 @@
+# Compare Open MPI to the PMIx Standard
+
+The goal of the functionality in this directory is to compare the OpenPMIx implementation with the PMIx Standard document. A script is used to generate a difference between the two. A 'triage' file is used to identify known differences.
+
+The output from this script can use used to assist the PMIx communities in making sure functionality is matched (as approprate) between the two projects on a regular basis.
+
+## Preparing the directory
+
+Checkout the necessary repos.
+
+By default the script will checkout `master` on both repos.
+```shell
+./bin/checkout-repos.sh
+```
+
+You can set the two envars seen below to customize that branch:
+```shell
+OPENPMIX_BRANCH='v4.2' PMIX_STANDARD_BRANCH='v4' ./bin/checkout-repos.sh
+```
+
+Example:
+```shell
+shell$ ./bin/checkout-repos.sh
+==========================
+OpenPMIx      : master
+PMIx Standard : master
+==========================
+========> Cloning OpenPMIx
+Cloning into 'openpmix'...
+remote: Enumerating objects: 48094, done.
+remote: Counting objects: 100% (252/252), done.
+remote: Compressing objects: 100% (138/138), done.
+remote: Total 48094 (delta 150), reused 183 (delta 114), pack-reused 47842
+Receiving objects: 100% (48094/48094), 20.61 MiB | 12.15 MiB/s, done.
+Resolving deltas: 100% (36646/36646), done.
+========> Cloning PMIx Standard
+Cloning into 'pmix-standard'...
+remote: Enumerating objects: 3177, done.
+remote: Counting objects: 100% (217/217), done.
+remote: Compressing objects: 100% (113/113), done.
+remote: Total 3177 (delta 115), reused 190 (delta 104), pack-reused 2960
+Receiving objects: 100% (3177/3177), 13.20 MiB | 9.48 MiB/s, done.
+Resolving deltas: 100% (2063/2063), done.
+========> Building PMIx Standard
+...
+========> Success
+```
+
+## Running the script
+
+Command line arguments:
+ * `-t` : Triage file (optional)
+ * `-v` : Verbose output
+ * `-d` : Verbose + Debugging output
+ * `--openpmix` : OpenPMIx git checkout (default `scratch/openpmix`)
+ * `--standard` : PMIx Standard git checkout (default `scratch/pmix-standard`)
+
+```shell
+./bin/compare-with-pmix-standard.py -t etc/openpmix_master-pmix-standard_master.txt
+```
+
+Example:
+```shell
+shell$ ./bin/compare-with-pmix-standard.py -t etc/openpmix_master-pmix-standard_master.txt
+--------------------------------------------------
+OpenPMIx Directory     : scratch/openpmix
+         Git Info.     : master (0b8d0435)
+PMIx Standard Directory: scratch/pmix-standard
+              Git Info.: master (78956843)
+Traige file            : etc/openpmix_master-pmix-standard_master.txt
+--------------------------------------------------
+   0 : Symbols missing from the PMIx Standard defined by OpenPMIx
+   0 : Symbols missing from OpenPMIx defined by the PMIx Standard
+ 210 : Symbols in triage file
+   0 : Symbols in triage file that were not missing.
+--------------------------------------------------
+Success! No missing symbols found!
+```
+
+## Update the triage files
+
+Edit the file in `etc/`
+
+## Update the branches in the script
+
+The OpenPMIx and PMIx Standard branches are defined in the following wrapper scripts.
+ * `bin/run-v4-check.sh` : Check OpenPMIx against the v4 PMIx Standard
+ * `bin/run-v5-check.sh` : Check OpenPMIx against the v5 PMIx Standard
+
+Look for the `OPENPMIX_BRANCH` and `PMIX_STANDARD_BRANCH` envars in those scripts. Adjusting the values of these envars will select the respective branch in that repository.
+
+## Run in the Docker environment
+
+Example to run the full v5 check using your local version of `pmix-tests`:
+```shell
+docker run --rm -v /host/path/to/pmix-tests:/home/pmixer/pmix-tests jjhursey/pmix-standard /bin/bash -c "cd /tmp ; /home/pmixer/pmix-tests/check-standard/bin/run-v5-check.sh"
+```
+

--- a/check-standard/bin/checkout-repos.sh
+++ b/check-standard/bin/checkout-repos.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -e
+
+#-------------------------
+# 'master', 'v4.2'
+OPENPMIX_BRANCH="${OPENPMIX_BRANCH:-master}"
+
+# 'master', 'v4'
+PMIX_STANDARD_BRANCH="${PMIX_STANDARD_BRANCH:-master}"
+
+echo "=========================="
+echo "OpenPMIx      : "${OPENPMIX_BRANCH}
+echo "PMIx Standard : "${PMIX_STANDARD_BRANCH}
+echo "=========================="
+
+#-------------------------
+_OPENPMIX_DIR=${PWD}"/scratch/openpmix"
+_PMIX_STANDARD_DIR=${PWD}"/scratch/pmix-standard"
+if [[ -d ${_OPENPMIX_DIR} ]] ; then
+    echo "Error: The OpenPMIx directory exists. Please remove and re-run."
+    echo "       ${_OPENPMIX_DIR}"
+    exit 1
+fi
+if [[ -d ${_OPENPMIX_DIR} ]] ; then
+    echo "Error: The PMIx Standard directory exists. Please remove and re-run."
+    echo "       ${PMIX_STANDARD_BRANCH}"
+    exit 1
+fi
+
+#-------------------------
+mkdir -p scratch
+cd scratch
+
+echo "========> Cloning OpenPMIx"
+git clone -b ${OPENPMIX_BRANCH} https://github.com/openpmix/openpmix.git openpmix
+
+echo "========> Cloning PMIx Standard"
+git clone -b ${PMIX_STANDARD_BRANCH} https://github.com/pmix/pmix-standard.git pmix-standard
+
+echo "========> Building PMIx Standard"
+cd pmix-standard
+make
+
+echo "========> Success"
+exit 0

--- a/check-standard/bin/compare-with-pmix-standard.py
+++ b/check-standard/bin/compare-with-pmix-standard.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env -S python3 -u
+
+import sys
+import os
+import re
+import argparse
+import subprocess
+import shutil
+
+args = None
+all_triage_symbols = []
+
+def extract_git_info(dir):
+    prev_cwd = os.getcwd()
+    os.chdir(dir)
+
+    git_branch = None
+    git_hash = None
+
+    p = subprocess.Popen("git rev-parse --abbrev-ref HEAD",
+                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=True)
+    p.wait()
+    if p.returncode != 0:
+        print("Error: Failed to extract the git branch in the directory. "+dir+" Error code "+str(p.returncode)+")");
+        os.chdir(prev_cwd)
+        return "Unknown"
+
+    for line in p.stdout:
+        line = line.rstrip()
+        line = line.decode()
+        git_branch = line
+        break
+
+    p = subprocess.Popen("git rev-parse --short HEAD",
+                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=True)
+    p.wait()
+    if p.returncode != 0:
+        print("Error: Failed to extract the git revision in the directory. "+dir+" Error code "+str(p.returncode)+")");
+        os.chdir(prev_cwd)
+        return "Unknown"
+
+    for line in p.stdout:
+        line = line.rstrip()
+        line = line.decode()
+        git_hash = line
+        break
+
+    os.chdir(prev_cwd)
+    if git_branch is not None and git_hash is not None:
+        return git_branch +" ("+git_hash+")"
+    else:
+        return "Unknown"
+
+
+def extract_triage(triage_file):
+    """Extract traige symbols"""
+
+    global args
+    triage_symbols = []
+
+    with open(args.triage_file, 'r') as tf:
+        for line in tf:
+            line = line.rstrip()
+
+            # Line comments
+            m = re.match(r'^#', line)
+            if m is not None:
+                continue
+
+            # Empty lines
+            m = re.match(r'^\s*$', line)
+            if m is not None:
+                continue
+
+            triage_symbols.append(line)
+
+    return triage_symbols
+
+def pmix_standard_encode(ref_str):
+    """Encode the PMIx Standard LaTeX reference string as something more readable"""
+
+    if ref_str == "apifn":
+        return "API"
+    elif ref_str == "attr":
+        return "attribute"
+    elif ref_str == "const":
+        return "constant"
+    elif ref_str == "envar":
+        return "envar"
+    elif ref_str == "macro":
+        return "macro"
+    elif ref_str == "struct":
+        return "struct"
+    else:
+        print("Error: Unknown reference: "+ref_str)
+        os._exit(1)
+
+def extract_pmix_standard(pmix_standard_dir):
+    """Extract symbols from the PMIx Standard"""
+
+    global args
+    all_symbols = {}
+    all_symbols_raw = {}
+    std_deprecated = {}
+    std_removed = {}
+
+    # --------------------------------------------------
+    # attributes - grep "newlabel{attr" pmix-standard.aux
+    # consts     - grep "newlabel{const" pmix-standard.aux
+    # structs    - grep "newlabel{struct" pmix-standard.aux
+    # macros     - grep "newlabel{macro" pmix-standard.aux
+    # apis       - grep "newlabel{api" pmix-standard.aux
+    # envars     - grep "newlabel{envar" pmix-standard.aux
+    # --------------------------------------------------
+    all_ref_strs = ["attr", "const", "struct", "macro", "apifn", "envar"]
+    for ref_str in all_ref_strs:
+        cur_set_of_symbols = {}
+
+        if args.verbose is True:
+            print ("-"*5 + "> Extracting PMIx Standard: \""+ref_str+"\"")
+
+        # Exclude:
+        #   subsection.A => Appendix A: Python Bindings
+        p = subprocess.Popen("grep \"newlabel{"+ref_str+"\" "+pmix_standard_dir+"/pmix-standard.aux | grep -v subsection.A",
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=True)
+        p.wait()
+        if p.returncode != 0:
+            print("Error: Failed to extract declared \""+ref_str+"\". grep error code "+str(p.returncode)+")");
+            sys.exit(2)
+
+        for line in p.stdout:
+            line = line.rstrip()
+            line = line.decode()
+            m = re.match(r"\s*\\newlabel{"+ re.escape(ref_str) + r":(\w+)", line)
+            if m is None:
+                print("Error: Failed to extract an \""+ref_str+"\" on the following line")
+                print(" line: "+line)
+                sys.exit(1)
+
+            # Count will return to 0 when verified
+            all_symbols_raw[m.group(1)] = -1
+            if "Deprecated" in line:
+                std_deprecated[m.group(1)] = -1
+            elif re.search('removed', line, re.IGNORECASE):
+                std_removed[m.group(1)] = -1
+            else:
+                cur_set_of_symbols[m.group(1)] = -1
+
+        all_symbols[pmix_standard_encode(ref_str)] = cur_set_of_symbols
+
+    all_symbols['deprecated'] = std_deprecated
+    all_symbols['removed'] = std_removed
+
+    # --------------------------------------------------
+    if args.verbose is True:
+        print ("-"*50)
+        for ref_str in sorted(all_symbols):
+            print("PMIx Standard Reference \"%10s\" : %4d" % (ref_str, len(all_symbols[ref_str])))
+            if args.debug is True:
+                for val in sorted(all_symbols[ref_str]):
+                    print("  +---> " + val)
+        print ("-"*50)
+
+    return all_symbols
+
+def extract_openpmix(openpmix_dir):
+    """Extract symbols from OpenPMIx"""
+
+    global args
+    all_symbols = {}
+    openpmix_deprecated = {}
+
+    openpmix_defines = {}
+    openpmix_structs = {}
+    openpmix_apis = {}
+    openpmix_cbs = {}
+    openpmix_all_refs = {}
+
+    # Extract the header files
+    openpmix_files = []
+    for fname in os.listdir(openpmix_dir + "/include"):
+        m = re.search(r'.h', fname)
+        if m is not None:
+            m = re.search(r'pmi[2]?.h', fname) # Exclude pmi.h and pmi2.h
+            if m is None:
+                openpmix_files.append(fname)
+
+    # For each header file, extract the symbols
+    for openpmix_file in sorted(openpmix_files):
+        openpmix_file = openpmix_dir + "/include/" + openpmix_file
+        if args.verbose is True:
+            print("-"*5 + "> Extracting OpenPMIx Definitions from: " + openpmix_file)
+
+        if "deprecated.h" in openpmix_file:
+            parse_deprecated = True
+        else:
+            parse_deprecated = False
+        parse_active = False
+        parse_enum = False
+        parse_struct = False
+        defs_found = 0
+        with open(openpmix_file) as fp:
+            for line in fp:
+                line = line.rstrip()
+
+                m = re.match(r'extern "C"', line);
+                if m is None and parse_active is False:
+                    continue
+                else:
+                    parse_active = True
+
+                # typedef enum {
+                m = re.match(r'\s*typedef\s+enum\s*', line);
+                if m is not None:
+                    parse_enum = True
+                    continue
+                if parse_enum is True:
+                    m = re.match(r'\s*}\s*(pmi\w*)', line)
+                    if m is not None:
+                        if parse_deprecated:
+                            openpmix_deprecated[m.group(1)] = -1
+                        else:
+                            openpmix_structs[m.group(1)] = -1
+                            openpmix_all_refs[m.group(1)] = -1
+                        defs_found = defs_found + 1
+                        parse_enum = False
+                        continue
+                    m = re.match(r'\s+(\w+)', line)
+                    if m is not None:
+                        if parse_deprecated:
+                            openpmix_deprecated[m.group(1)] = -1
+                        else:
+                            openpmix_defines[m.group(1)] = -1
+                            openpmix_all_refs[m.group(1)] = -1
+                        defs_found = defs_found + 1
+                        continue
+
+                # typedef struct pmix_data_buffer {
+                m = re.match(r'\s*typedef\s+struct\s*\w+\s+{', line);
+                if m is not None:
+                    parse_struct = True
+                    continue
+                else:
+                    m = re.match(r'\s*typedef\s+struct\s*{', line);
+                    if m is not None:
+                        parse_struct = True
+                        continue
+                if parse_struct is True:
+                    m = re.match(r'\s*}\s*(pmi\w+)', line)
+                    if m is not None:
+                        if parse_deprecated:
+                            openpmix_deprecated[m.group(1)] = -1
+                        else:
+                            openpmix_structs[m.group(1)] = -1
+                            openpmix_all_refs[m.group(1)] = -1
+                        defs_found = defs_found + 1
+                        parse_struct = False
+                        continue
+                    else:
+                        continue
+
+                # typedef uint8_t pmix_data_range_t;
+                m = re.match(r'\s*typedef\s*\w*\s*(pmi\w*)[;|\[]', line);
+                if m is not None:
+                    if parse_deprecated:
+                        openpmix_deprecated[m.group(1)] = -1
+                    else:
+                        openpmix_structs[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+
+                # #define PMIX_EVENT_BASE                     "pmix.evbase"
+                m = re.match(r'#define\s+(\w+)\(', line);
+                if m is not None:
+                    if parse_deprecated:
+                        openpmix_deprecated[m.group(1)] = -1
+                    else:
+                        openpmix_defines[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+
+                # #define PMIx_Heartbeat()
+                m = re.match(r'#define\s+(\w+)', line);
+                if m is not None:
+                    if parse_deprecated:
+                        openpmix_deprecated[m.group(1)] = -1
+                    else:
+                        openpmix_defines[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+
+                # PMIX_EXPORT const char* PMIx_Error_string
+                m = re.match(r'PMIX_EXPORT\s+\w+\s+\w+\*\s+(PMI\w+)', line);
+                if m is not None:
+                    if parse_deprecated:
+                        openpmix_deprecated[m.group(1)] = -1
+                    else:
+                        openpmix_apis[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+
+                # PMIX_EXPORT <type>* PMI<function>
+                m = re.match(r'PMIX_EXPORT\s+\w+\*\s+(PMI\w+)', line);
+                if m is not None:
+                    if parse_deprecated:
+                        openpmix_deprecated[m.group(1)] = -1
+                    else:
+                        openpmix_apis[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+
+                # PMIX_EXPORT <type>** PMI<function>
+                m = re.match(r'PMIX_EXPORT\s+\w+\*+\*+\s+(PMI\w+)', line);
+                if m is not None:
+                    if parse_deprecated:
+                        openpmix_deprecated[m.group(1)] = -1
+                    else:
+                        openpmix_apis[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+
+                # PMIX_EXPORT <type> *PMI<function>
+                m = re.match(r'PMIX_EXPORT\s+\w+\s+\*+(PMI\w+)', line);
+                if m is not None:
+                    if parse_deprecated:
+                        openpmix_deprecated[m.group(1)] = -1
+                    else:
+                        openpmix_apis[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+
+                # PMIX_EXPORT <type> **PMI<function>
+                m = re.match(r'PMIX_EXPORT\s+\w+\s+\*+\*+(PMI\w+)', line);
+                if m is not None:
+                    if parse_deprecated:
+                        openpmix_deprecated[m.group(1)] = -1
+                    else:
+                        openpmix_apis[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+
+                # PMIX_EXPORT pmix_status_t PMIx_Init(
+                m = re.match(r'PMIX_EXPORT\s+\w+\s+(PMI\w+)', line);
+                if m is not None:
+                    if parse_deprecated:
+                        openpmix_deprecated[m.group(1)] = -1
+                    else:
+                        openpmix_apis[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+
+                # typedef void (*pmix_iof_cbfunc_t)(
+                m = re.match(r'\s*typedef\s+\w+\s+\(\*(\w+)', line);
+                if m is not None:
+                    if parse_deprecated:
+                        openpmix_deprecated[m.group(1)] = -1
+                    else:
+                        openpmix_cbs[m.group(1)] = -1
+                        openpmix_all_refs[m.group(1)] = -1
+                    defs_found = defs_found + 1
+                    continue
+
+    all_symbols['define'] = openpmix_defines
+    all_symbols['struct'] = openpmix_structs
+    all_symbols['API'] = openpmix_apis
+    all_symbols['callback'] = openpmix_cbs
+
+    # Prune the deprecated list
+    # Note: Some items are declared in both the pmix.h and pmix_deprecated.h
+    #       to make the old interfaces easier to access. Remove those duplicates.
+    for ref_str in all_symbols:
+        for val in all_symbols[ref_str]:
+            if val in openpmix_deprecated.keys():
+                del openpmix_deprecated[val]
+    all_symbols['deprecated'] = openpmix_deprecated
+
+    if args.verbose is True:
+        print ("-"*50)
+        for ref_str in sorted(all_symbols):
+            print("OpenPMIx Reference \"%10s\" : %4d" % (ref_str, len(all_symbols[ref_str])))
+            if args.debug is True:
+                for val in sorted(all_symbols[ref_str]):
+                    print("  +---> " + val)
+        print ("-"*50)
+
+    return all_symbols
+
+def compare_openpmix_to_pmix_standard(openpmix_symbols, pmix_standard_symbols, all_triage_symbols):
+    """Compare OpenPMIx symbols to PMIx Standard"""
+
+    if args.verbose is True:
+        print ("-"*5 + "> Checking for OpenPMIx symbols not in the PMIx Standard")
+
+    # Flatten the lists
+    all_openpmix_symbols = {}
+    for ref_str in openpmix_symbols:
+        for val in openpmix_symbols[ref_str]:
+            all_openpmix_symbols[val] = -1;
+    all_pmix_standard_symbols = {}
+    for ref_str in pmix_standard_symbols:
+        for val in pmix_standard_symbols[ref_str]:
+            all_pmix_standard_symbols[val] = -1;
+
+    # Iterate through the lists to find missing references
+    all_missing_refs = {}
+    missing_refs = []
+    missing_refs_triaged = []
+    for openpmix_ref in all_openpmix_symbols:
+        found_ref = False
+
+        # Symbol in both OpenPMIx and PMIx Standard
+        if openpmix_ref in all_pmix_standard_symbols.keys():
+            found_ref = True
+
+        # Exclude deprecated symbols
+        if found_ref is False:
+            if openpmix_ref in openpmix_symbols['deprecated'].keys():
+                found_ref = True
+
+        # Exclude triaged symbols
+        if found_ref is False:
+            if openpmix_ref in all_triage_symbols:
+                missing_refs_triaged.append(openpmix_ref)
+                found_ref = True
+
+        # Found a missing symbol
+        if found_ref is False:
+            missing_refs.append(openpmix_ref)
+
+    all_missing_refs['missing'] = missing_refs
+    all_missing_refs['triaged'] = missing_refs_triaged
+    return all_missing_refs
+
+def compare_pmix_standard_to_openpmix(openpmix_symbols, pmix_standard_symbols, all_triage_symbols):
+    """Compare PMIx Standard symbols to OpenPMIx"""
+
+    if args.verbose is True:
+        print ("-"*5 + "> Checking for PMIx Standard symbols not in OpenPMIx")
+
+    # Flatten the lists
+    all_openpmix_symbols = {}
+    for ref_str in openpmix_symbols:
+        for val in openpmix_symbols[ref_str]:
+            all_openpmix_symbols[val] = -1;
+    all_pmix_standard_symbols = {}
+    for ref_str in pmix_standard_symbols:
+        for val in pmix_standard_symbols[ref_str]:
+            all_pmix_standard_symbols[val] = -1;
+
+    # Iterate through the lists to find missing references
+    all_missing_refs = {}
+    missing_refs = []
+    missing_refs_triaged = []
+    for pmix_standard_ref in all_pmix_standard_symbols:
+        found_ref = False
+
+        # Symbol in both OpenPMIx and PMIx Standard
+        if pmix_standard_ref in all_openpmix_symbols.keys():
+            found_ref = True
+
+        # Exclude deprecated and removed
+        if found_ref is False:
+            if pmix_standard_ref in pmix_standard_symbols['deprecated'].keys():
+                found_ref = True
+            elif pmix_standard_ref in pmix_standard_symbols['removed'].keys():
+                found_ref = True
+
+        # Exclude triaged symbols
+        if found_ref is False:
+            if pmix_standard_ref in all_triage_symbols:
+                missing_refs_triaged.append(pmix_standard_ref)
+                found_ref = True
+
+        # Found a missing symbol
+        if found_ref is False:
+            missing_refs.append(pmix_standard_ref)
+
+    all_missing_refs['missing'] = missing_refs
+    all_missing_refs['triaged'] = missing_refs_triaged
+    return all_missing_refs
+
+if __name__ == "__main__":
+
+    #
+    # Command line parsing
+    #
+    parser = argparse.ArgumentParser(description="PMIx Standard / OpenPMIx Cross Check")
+    parser.add_argument("-v", "--verbose", help="Verbose output", action="store_true")
+    parser.add_argument("-d", "--debug", help="Extra debug output", action="store_true")
+    parser.add_argument("-o", "--openpmix", help="OpenPMIx checkout directory", nargs='?', default='scratch/openpmix', dest="openpmix_dir")
+    parser.add_argument("-s", "--standard", help="PMIx Standard checkout directory", nargs='?', default='scratch/pmix-standard', dest="pmix_standard_dir")
+    parser.add_argument("-t", "--triage", help="Traige file of symbols in OpenPMIx not in PMIx Standard", required=False, dest="triage_file")
+
+    parser.parse_args()
+    args = parser.parse_args()
+
+    if args.debug is True:
+        args.verbose = True
+
+    #
+    # OpenPMIx
+    #
+    if args.openpmix_dir is not None and os.path.isdir(args.openpmix_dir) is False:
+        print("Error: OpenPMIx directory not found. " + args.openpmix_dir)
+        os._exit(1)
+
+    #
+    # PMIx Standard
+    #
+    if args.pmix_standard_dir is not None and os.path.isdir(args.pmix_standard_dir) is False:
+        print("Error: PMIx Standard directory not found. " + args.pmix_standard_dir)
+        os._exit(1)
+
+    if os.path.isfile(args.pmix_standard_dir + "/pmix-standard.aux") is False:
+        print("Error: PMIx Standard was not compiled. Missing: " + args.pmix_standard_dir + "/pmix-standard.aux")
+        os._exit(1)
+
+    #
+    # Triage file
+    #
+    if args.triage_file is not None and os.path.isfile(args.triage_file) is False:
+        print("Error: Triage File not found. " + args.triage_file)
+        os._exit(1)
+
+    if args.triage_file is not None:
+        all_triage_symbols = extract_triage(args.triage_file)
+
+    #
+    # Diagnostic output
+    #
+    print("-"*50)
+    print("OpenPMIx Directory     : " + args.openpmix_dir)
+    print("         Git Info.     : " + extract_git_info(args.openpmix_dir))
+    print("PMIx Standard Directory: " + args.pmix_standard_dir)
+    print("              Git Info.: " + extract_git_info(args.pmix_standard_dir))
+    if args.triage_file is not None:
+        print("Traige file            : " + args.triage_file)
+    print("-"*50)
+
+    #
+    # Extract symbols from PMIx Standard
+    #
+    pmix_standard_symbols = extract_pmix_standard(args.pmix_standard_dir)
+
+    #
+    # Extract symbols from OpenPMIx
+    #
+    openpmix_symbols = extract_openpmix(args.openpmix_dir)
+
+    #
+    # Check: Items defined in OpenPMIx are in the PMIx Standard
+    #
+    missing_from_pmix_standard = compare_openpmix_to_pmix_standard(openpmix_symbols, pmix_standard_symbols, all_triage_symbols)
+    total_missing_pmix_standard = len(missing_from_pmix_standard['missing'])
+
+    #
+    # Check: Items defined in PMIx Standard are in OpenPMIx
+    #
+    missing_from_openpmix = compare_pmix_standard_to_openpmix(openpmix_symbols, pmix_standard_symbols, all_triage_symbols)
+    total_missing_openpmix = len(missing_from_openpmix['missing'])
+
+    print("%4d : Symbols missing from the PMIx Standard defined by OpenPMIx" % (total_missing_pmix_standard))
+    print("%4d : Symbols missing from OpenPMIx defined by the PMIx Standard" % (total_missing_openpmix))
+    print("%4d : Symbols in triage file" % (len(all_triage_symbols)))
+
+    #
+    # Double check the triage list
+    #
+    for t_ref in missing_from_pmix_standard['triaged']:
+        if t_ref in all_triage_symbols:
+            all_triage_symbols.remove(t_ref)
+    for t_ref in missing_from_openpmix['triaged']:
+        if t_ref in all_triage_symbols:
+            all_triage_symbols.remove(t_ref)
+
+    total_triage_leftovers = len(all_triage_symbols)
+    print("%4d : Symbols in triage file that were not missing." % (total_triage_leftovers))
+
+    #
+    # Final output
+    #
+    print("-"*50)
+
+    if total_triage_leftovers > 0:
+        print("===> Warning: %d symbols in the Triage file were not missing. Check the triage file" % (total_triage_leftovers))
+        for t_ref in sorted(all_triage_symbols):
+            print(t_ref)
+        print("-"*50)
+
+
+    if total_missing_pmix_standard == 0 and total_missing_openpmix == 0:
+        print("Success! No missing symbols found!")
+        os._exit(0)
+    else:
+        if total_missing_pmix_standard > 0:
+            print("===> PMIx Standard is missing the following symbols:")
+            print("-"*25)
+            for val in sorted(missing_from_pmix_standard['missing']):
+                print(val)
+
+        if total_missing_openpmix > 0:
+            print("===> OpenPMIx is missing the following symbols:")
+            print("-"*25)
+            for val in sorted(missing_from_openpmix['missing']):
+                print(val)
+
+        os._exit(total_missing_pmix_standard + total_missing_openpmix)
+
+    # --------------------------------------------------
+    # Check to make sure that all of the items defined in OpenPMIx are in the PMIx Standard
+    # - except for those explicitly excluded
+    # --------------------------------------------------
+    total_missing_refs = 0
+
+    missing_refs = check_missing_pmix_standard(std_all_refs, openpmix_all_refs,
+                                               std_deprecated, std_removed,
+                                               openpmix_deprecated,
+                                               args.verbose)
+    total_missing_refs = total_missing_refs + len(missing_refs)
+    if len(missing_refs) > 0:
+        print ("-"*50)
+        print("Found "+str(len(missing_refs))+" references defined in OpenPMIx, but not in the PMIx Standard")
+        for ref in sorted(missing_refs):
+            print("PMIx Standard Missing: "+ref)
+        print("")
+
+    if len(all_triage_symbols) > 0:
+        print("-"*50)
+        print("Found "+str(len(all_triage_symbols))+" references defined in the Triage file, but were not listed as in OpenPMIx, but not in the PMIx Standard")
+        print("Please check these references in your traige file!")
+
+        for ref in sorted(all_triage_symbols):
+            print("Triage Reference: "+ref)
+
+
+    # --------------------------------------------------
+    # Check to make sure that all of the items defined in the PMIx Standard are in OpenPMIx
+    # --------------------------------------------------
+    missing_refs = check_missing_openpmix(std_all_refs, openpmix_all_refs,
+                                          std_deprecated, std_removed,
+                                          openpmix_deprecated, args.verbose)
+    total_missing_refs = total_missing_refs + len(missing_refs)
+    if len(missing_refs) > 0:
+        print ("-"*50)
+        print("Found "+str(len(missing_refs))+" references defined in PMIx Standard, but not in OpenPMIx")
+        for ref in sorted(missing_refs):
+            print("OpenPMIx Missing: "+ref)
+        print("")
+
+
+    # Return the total number of missing references
+    sys.exit(total_missing_refs)
+

--- a/check-standard/bin/run-v4-check.sh
+++ b/check-standard/bin/run-v4-check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+SCRIPT_DIR=`dirname $0`
+
+OPENPMIX_BRANCH='v4.2' PMIX_STANDARD_BRANCH='v4' $SCRIPT_DIR/checkout-repos.sh
+mv scratch scratch-v4
+
+$SCRIPT_DIR/compare-with-pmix-standard.py --openpmix scratch-v4/openpmix --standard scratch-v4/pmix-standard -t ${SCRIPT_DIR}/../etc/openpmix_v4-pmix-standard_v4.txt

--- a/check-standard/bin/run-v5-check.sh
+++ b/check-standard/bin/run-v5-check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+SCRIPT_DIR=`dirname $0`
+
+OPENPMIX_BRANCH='master' PMIX_STANDARD_BRANCH='master' $SCRIPT_DIR/checkout-repos.sh
+mv scratch scratch-v5
+
+$SCRIPT_DIR/compare-with-pmix-standard.py --openpmix scratch-v5/openpmix --standard scratch-v5/pmix-standard -t ${SCRIPT_DIR}/../etc/openpmix_master-pmix-standard_master.txt

--- a/check-standard/etc/openpmix_master-pmix-standard_master.txt
+++ b/check-standard/etc/openpmix_master-pmix-standard_master.txt
@@ -1,0 +1,409 @@
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: ce5c8327f
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_NUM_KEYS
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: fb4a57ba1
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_WDIR_USER_SPECIFIED
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: e66c29b93
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_SORTED_PROC_ARRAY
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 4b837827f
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_QUERY_ALLOCATION
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 3a8ef0946
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_MYSERVER_URI
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: d490e100a
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_LOG_AGG
+PMIX_LOG_KEY
+PMIX_LOG_VAL
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 73aff171c
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_IOF_TAG_DETAILED_OUTPUT
+PMIX_IOF_TAG_FULLNAME_OUTPUT
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 70d5a53ae
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_EXTERNAL_AUX_EVENT_BASE
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 518dc6aed
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_EVENT_ONESHOT
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 5dab544ec
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_ERR_EXIT_NONZERO_TERM
+PMIX_ERR_PROC_ABORTED_BY_SIG
+PMIX_ERR_PROC_FAILED_TO_START
+PMIX_ERR_PROC_KILLED_BY_CMD
+PMIX_ERR_PROC_SENSOR_BOUND_EXCEEDED
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 29a92a17b
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_DISPLAY_PROCESSORS
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 1ba4ee6e7
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_DISPLAY_PARSEABLE_OUTPUT
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 195e36f1d
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_DISPLAY_ALLOCATION
+PMIX_DISPLAY_MAP_DETAILED
+PMIX_DISPLAY_TOPOLOGY
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: fcc07f946
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_DATA_BUFFER
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 137cc3d6b
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_COLOCATE_NPERNODE
+PMIX_COLOCATE_NPERPROC
+PMIX_COLOCATE_PROCS
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: d167a63f5
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_BIND_PROGRESS_THREAD
+PMIX_BIND_REQUIRED
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: da240c502
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_RUNTIME_OPTIONS
+PMIX_ABORT_NON_ZERO_TERM
+PMIX_DO_NOT_LAUNCH
+PMIX_SHOW_LAUNCH_PROGRESS
+PMIX_AGGREGATE_HELP
+PMIX_REPORT_CHILD_SEP
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: f825ed08e
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_TOPOLOGY_INDEX
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 0a9aa8c8b
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_tool_is_connected
+PMIX_CONNECT_TO_SCHEDULER
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 261702212
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_ALLOC_PREEMPTIBLE
+PMIX_SESSION_APP
+PMIX_SESSION_COMPLETE
+PMIX_SESSION_CTRL_ID
+PMIX_SESSION_PAUSE
+PMIX_SESSION_PREEMPT
+PMIX_SESSION_PROVISION
+PMIX_SESSION_PROVISION_IMAGE
+PMIX_SESSION_PROVISION_NODES
+PMIX_SESSION_RESTORE
+PMIX_SESSION_RESUME
+PMIX_SESSION_SIGNAL
+PMIX_SESSION_TERMINATE
+PMIX_ALLOC_REQ_CANCEL
+pmix_server_session_control_fn_t
+PMIx_Session_control
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: dad0fb856
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Info_list_insert
+PMIX_INFO_PERSISTENT
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 7a0fa0455
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Device_distance_construct
+PMIx_Device_distance_create
+PMIx_Device_distance_destruct
+PMIx_Device_distance_free
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: d56cc5fdb
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_App_string
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: ec77b2bfa
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_QUALIFIED_VALUE
+PMIX_GROUP_INFO
+PMIX_GROUP_LOCAL_CID
+PMIX_GROUP_ADD_MEMBERS
+PMIX_INFO_QUALIFIER
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: a4e83b627
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Value_true
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 7931d879c
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Info_string
+PMIx_Value_string
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: ea977cd55
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Value_get_size
+PMIx_Info_get_size
+PMIx_Info_list_prepend
+PMIx_Info_list_get_info
+PMIX_SIZE_ESTIMATE
+
+#---------------------------------------------------------
+# Needs Review: Likely more macro to function conversions
+#  OpenPMIx: a37ef140f
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Xfer_procid
+PMIx_Argv_append_nosize
+PMIx_Argv_append_unique_nosize
+PMIx_Argv_prepend_nosize
+PMIx_Argv_split_inter
+PMIx_Argv_split_with_empty
+PMIx_Info_set_end
+PMIx_Info_qualifier
+PMIx_Info_is_qualifier
+PMIx_Info_persistent
+PMIx_Info_is_persistent
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: fec3c6f6f
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Value_compare
+PMIx_Value_comparison_string
+pmix_value_cmp_t
+PMIX_EQUAL
+PMIX_VALUE1_GREATER
+PMIX_VALUE2_GREATER
+PMIX_VALUE_COMPARISON_NOT_AVAIL
+PMIX_VALUE_INCOMPATIBLE_OBJECTS
+PMIX_VALUE_TYPE_DIFFERENT
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 6927bc40c
+#  OpenPMIx PR: https://github.com/openpmix/openpmix/pull/2738
+#
+# Return value for:
+#  - PMIx_Value_true which replaced macros PMIX_CHECK_TRUE / PMIX_CHECK_BOOL
+#  - PMIx_Info_true which replaced macro PMIX_INFO_TRUE
+#---------------------------------------------------------
+PMIX_BOOL_FALSE
+PMIX_BOOL_TRUE
+PMIX_NON_BOOL
+pmix_boolean_t
+# PMIX_CHECK_TRUE
+# pmix_check_true
+
+#---------------------------------------------------------
+# Pending PMIx Standard PR:
+#   https://github.com/pmix/pmix-standard/pull/335
+#  OpenPMIx PR: https://github.com/openpmix/openpmix/pull/2039
+#    Comment about missing parts: https://github.com/openpmix/openpmix/pull/2039
+#---------------------------------------------------------
+pmix_proc_stats_t
+PMIx_Proc_stats_construct
+PMIx_Proc_stats_create
+PMIx_Proc_stats_destruct
+PMIx_Proc_stats_free
+PMIX_PROC_STATS
+PMIX_PROC_STATS_STATIC_INIT
+pmix_node_stats_t
+PMIX_NODE_STATS
+PMIX_NODE_STATS_STATIC_INIT
+
+# Below are missing from PR 335 as of now
+pmix_disk_stats_t
+PMIX_DISK_STATS
+PMIX_DISK_STATS_STATIC_INIT
+PMIx_Disk_stats_construct
+PMIx_Disk_stats_create
+PMIx_Disk_stats_destruct
+PMIx_Disk_stats_free
+
+pmix_net_stats_t
+PMIX_NET_STATS
+PMIX_NET_STATS_STATIC_INIT
+PMIx_Net_stats_construct
+PMIx_Net_stats_create
+PMIx_Net_stats_destruct
+PMIx_Net_stats_free
+
+#---------------------------------------------------------
+# TODO: Macro -> Function conversion
+#---------------------------------------------------------
+PMIx_App_construct
+PMIx_App_create
+PMIx_App_destruct
+PMIx_App_free
+PMIx_App_info_create
+PMIx_App_release
+PMIx_Argv_copy
+PMIx_Argv_count
+PMIx_Argv_free
+PMIx_Argv_join
+PMIx_Argv_split
+PMIx_Byte_object_construct
+PMIx_Byte_object_create
+PMIx_Byte_object_destruct
+PMIx_Byte_object_free
+PMIx_Byte_object_load
+PMIx_Check_key
+PMIx_Check_nspace
+PMIx_Check_procid
+PMIx_Check_rank
+PMIx_Check_reserved_key
+PMIx_Coord_construct
+PMIx_Coord_create
+PMIx_Coord_destruct
+PMIx_Coord_free
+PMIx_Cpuset_construct
+PMIx_Cpuset_create
+PMIx_Cpuset_destruct
+PMIx_Cpuset_free
+PMIx_Data_array_destruct
+PMIx_Data_buffer_construct
+PMIx_Data_buffer_create
+PMIx_Data_buffer_destruct
+PMIx_Data_buffer_load
+PMIx_Data_buffer_release
+PMIx_Data_buffer_unload
+PMIx_Endpoint_construct
+PMIx_Endpoint_create
+PMIx_Endpoint_destruct
+PMIx_Endpoint_free
+PMIx_Envar_construct
+PMIx_Envar_create
+PMIx_Envar_destruct
+PMIx_Envar_free
+PMIx_Envar_load
+PMIx_Geometry_construct
+PMIx_Geometry_create
+PMIx_Geometry_destruct
+PMIx_Geometry_free
+PMIx_Info_construct
+PMIx_Info_create
+PMIx_Info_destruct
+PMIx_Info_free
+PMIx_Info_is_end
+PMIx_Info_is_optional
+PMIx_Info_is_required
+PMIx_Info_optional
+PMIx_Info_processed
+PMIx_Info_required
+PMIx_Info_true
+PMIx_Info_was_processed
+PMIx_Load_key
+PMIx_Load_nspace
+PMIx_Load_procid
+PMIx_Multicluster_nspace_construct
+PMIx_Multicluster_nspace_parse
+PMIx_Nspace_invalid
+PMIx_Pdata_construct
+PMIx_Pdata_create
+PMIx_Pdata_destruct
+PMIx_Pdata_free
+PMIx_Proc_construct
+PMIx_Proc_create
+PMIx_Proc_destruct
+PMIx_Proc_free
+PMIx_Proc_info_construct
+PMIx_Proc_info_create
+PMIx_Proc_info_destruct
+PMIx_Proc_info_free
+PMIx_Proc_load
+PMIx_Procid_invalid
+PMIx_Setenv
+PMIx_Topology_construct
+PMIx_Topology_create
+PMIx_Topology_free
+PMIx_Value_construct
+PMIx_Value_create
+PMIx_Value_destruct
+PMIx_Value_free

--- a/check-standard/etc/openpmix_v4-pmix-standard_v4.txt
+++ b/check-standard/etc/openpmix_v4-pmix-standard_v4.txt
@@ -1,0 +1,383 @@
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: fb4a57ba1
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_WDIR_USER_SPECIFIED
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: e66c29b93
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_SORTED_PROC_ARRAY
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 3a8ef0946
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_MYSERVER_URI
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: d490e100a
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_LOG_AGG
+PMIX_LOG_KEY
+PMIX_LOG_VAL
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 73aff171c
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_IOF_TAG_DETAILED_OUTPUT
+PMIX_IOF_TAG_FULLNAME_OUTPUT
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 70d5a53ae
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_EXTERNAL_AUX_EVENT_BASE
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 518dc6aed
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_EVENT_ONESHOT
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 5dab544ec
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_ERR_EXIT_NONZERO_TERM
+PMIX_ERR_PROC_ABORTED_BY_SIG
+PMIX_ERR_PROC_FAILED_TO_START
+PMIX_ERR_PROC_KILLED_BY_CMD
+PMIX_ERR_PROC_SENSOR_BOUND_EXCEEDED
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 29a92a17b
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_DISPLAY_PROCESSORS
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 1ba4ee6e7
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_DISPLAY_PARSEABLE_OUTPUT
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 195e36f1d
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_DISPLAY_ALLOCATION
+PMIX_DISPLAY_MAP_DETAILED
+PMIX_DISPLAY_TOPOLOGY
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: fcc07f946
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_DATA_BUFFER
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 137cc3d6b
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_COLOCATE_NPERNODE
+PMIX_COLOCATE_NPERPROC
+PMIX_COLOCATE_PROCS
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: d167a63f5
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_BIND_PROGRESS_THREAD
+PMIX_BIND_REQUIRED
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: da240c502
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_RUNTIME_OPTIONS
+PMIX_ABORT_NON_ZERO_TERM
+PMIX_DO_NOT_LAUNCH
+PMIX_SHOW_LAUNCH_PROGRESS
+PMIX_AGGREGATE_HELP
+PMIX_REPORT_CHILD_SEP
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 0a9aa8c8b
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_tool_is_connected
+PMIX_CONNECT_TO_SCHEDULER
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 261702212
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_ALLOC_PREEMPTIBLE
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: dad0fb856
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Info_list_insert
+PMIX_INFO_PERSISTENT
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 7a0fa0455
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Device_distance_construct
+PMIx_Device_distance_create
+PMIx_Device_distance_destruct
+PMIx_Device_distance_free
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: d56cc5fdb
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_App_string
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: ec77b2bfa
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIX_QUALIFIED_VALUE
+PMIX_GROUP_INFO
+PMIX_GROUP_LOCAL_CID
+PMIX_GROUP_ADD_MEMBERS
+PMIX_INFO_QUALIFIER
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: a4e83b627
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Value_true
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 7931d879c
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Info_string
+PMIx_Value_string
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: ea977cd55
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Value_get_size
+PMIx_Info_get_size
+PMIx_Info_list_prepend
+PMIx_Info_list_get_info
+PMIX_SIZE_ESTIMATE
+
+#---------------------------------------------------------
+# Needs Review: Likely more macro to function conversions
+#  OpenPMIx: a37ef140f
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Xfer_procid
+PMIx_Argv_append_nosize
+PMIx_Argv_append_unique_nosize
+PMIx_Argv_prepend_nosize
+PMIx_Argv_split_inter
+PMIx_Argv_split_with_empty
+PMIx_Info_set_end
+PMIx_Info_qualifier
+PMIx_Info_is_qualifier
+PMIx_Info_persistent
+PMIx_Info_is_persistent
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: fec3c6f6f
+#  OpenPMIx PR: 
+#---------------------------------------------------------
+PMIx_Value_compare
+PMIx_Value_comparison_string
+pmix_value_cmp_t
+PMIX_EQUAL
+PMIX_VALUE1_GREATER
+PMIX_VALUE2_GREATER
+PMIX_VALUE_COMPARISON_NOT_AVAIL
+PMIX_VALUE_INCOMPATIBLE_OBJECTS
+PMIX_VALUE_TYPE_DIFFERENT
+
+#---------------------------------------------------------
+# Needs Review:
+#  OpenPMIx: 6927bc40c
+#  OpenPMIx PR: https://github.com/openpmix/openpmix/pull/2738
+#
+# Return value for:
+#  - PMIx_Value_true which replaced macros PMIX_CHECK_TRUE / PMIX_CHECK_BOOL
+#  - PMIx_Info_true which replaced macro PMIX_INFO_TRUE
+#---------------------------------------------------------
+PMIX_BOOL_FALSE
+PMIX_BOOL_TRUE
+PMIX_NON_BOOL
+pmix_boolean_t
+# PMIX_CHECK_TRUE
+# pmix_check_true
+
+#---------------------------------------------------------
+# Pending PMIx Standard PR:
+#   https://github.com/pmix/pmix-standard/pull/335
+#  OpenPMIx PR: https://github.com/openpmix/openpmix/pull/2039
+#    Comment about missing parts: https://github.com/openpmix/openpmix/pull/2039
+#---------------------------------------------------------
+pmix_proc_stats_t
+PMIx_Proc_stats_construct
+PMIx_Proc_stats_create
+PMIx_Proc_stats_destruct
+PMIx_Proc_stats_free
+PMIX_PROC_STATS
+PMIX_PROC_STATS_STATIC_INIT
+pmix_node_stats_t
+PMIX_NODE_STATS
+PMIX_NODE_STATS_STATIC_INIT
+
+# Below are missing from PR 335 as of now
+pmix_disk_stats_t
+PMIX_DISK_STATS
+PMIX_DISK_STATS_STATIC_INIT
+PMIx_Disk_stats_construct
+PMIx_Disk_stats_create
+PMIx_Disk_stats_destruct
+PMIx_Disk_stats_free
+
+pmix_net_stats_t
+PMIX_NET_STATS
+PMIX_NET_STATS_STATIC_INIT
+PMIx_Net_stats_construct
+PMIx_Net_stats_create
+PMIx_Net_stats_destruct
+PMIx_Net_stats_free
+
+#---------------------------------------------------------
+# TODO: Macro -> Function conversion
+#---------------------------------------------------------
+PMIx_App_construct
+PMIx_App_create
+PMIx_App_destruct
+PMIx_App_free
+PMIx_App_info_create
+PMIx_App_release
+PMIx_Argv_copy
+PMIx_Argv_count
+PMIx_Argv_free
+PMIx_Argv_join
+PMIx_Argv_split
+PMIx_Byte_object_construct
+PMIx_Byte_object_create
+PMIx_Byte_object_destruct
+PMIx_Byte_object_free
+PMIx_Byte_object_load
+PMIx_Check_key
+PMIx_Check_nspace
+PMIx_Check_procid
+PMIx_Check_rank
+PMIx_Check_reserved_key
+PMIx_Coord_construct
+PMIx_Coord_create
+PMIx_Coord_destruct
+PMIx_Coord_free
+PMIx_Cpuset_construct
+PMIx_Cpuset_create
+PMIx_Cpuset_destruct
+PMIx_Cpuset_free
+PMIx_Data_array_destruct
+PMIx_Data_buffer_construct
+PMIx_Data_buffer_create
+PMIx_Data_buffer_destruct
+PMIx_Data_buffer_load
+PMIx_Data_buffer_release
+PMIx_Data_buffer_unload
+PMIx_Endpoint_construct
+PMIx_Endpoint_create
+PMIx_Endpoint_destruct
+PMIx_Endpoint_free
+PMIx_Envar_construct
+PMIx_Envar_create
+PMIx_Envar_destruct
+PMIx_Envar_free
+PMIx_Envar_load
+PMIx_Geometry_construct
+PMIx_Geometry_create
+PMIx_Geometry_destruct
+PMIx_Geometry_free
+PMIx_Info_construct
+PMIx_Info_create
+PMIx_Info_destruct
+PMIx_Info_free
+PMIx_Info_is_end
+PMIx_Info_is_optional
+PMIx_Info_is_required
+PMIx_Info_optional
+PMIx_Info_processed
+PMIx_Info_required
+PMIx_Info_true
+PMIx_Info_was_processed
+PMIx_Load_key
+PMIx_Load_nspace
+PMIx_Load_procid
+PMIx_Multicluster_nspace_construct
+PMIx_Multicluster_nspace_parse
+PMIx_Nspace_invalid
+PMIx_Pdata_construct
+PMIx_Pdata_create
+PMIx_Pdata_destruct
+PMIx_Pdata_free
+PMIx_Proc_construct
+PMIx_Proc_create
+PMIx_Proc_destruct
+PMIx_Proc_free
+PMIx_Proc_info_construct
+PMIx_Proc_info_create
+PMIx_Proc_info_destruct
+PMIx_Proc_info_free
+PMIx_Proc_load
+PMIx_Procid_invalid
+PMIx_Setenv
+PMIx_Topology_construct
+PMIx_Topology_create
+PMIx_Topology_free
+PMIx_Value_construct
+PMIx_Value_create
+PMIx_Value_destruct
+PMIx_Value_free
+
+#---------------------------------------------------------
+# Items in OpenPMIx that are not in the PMIx Standard v4, but are in v5
+#---------------------------------------------------------
+PMIX_QUERY_PROVISIONAL_ABI_VERSION
+PMIX_QUERY_STABLE_ABI_VERSION
+PMIX_STOR_ACCESS
+PMIX_STOR_ACCESS_TYPE
+PMIX_STOR_MEDIUM
+PMIX_STOR_PERSIST


### PR DESCRIPTION
 * Adds a script that checks out and compares the PMIx Standard with an OpenPMIx branch.
   - Currently `v4` and `v5` checked
 * Adds CI to run these checks in GitHub Actions
   - Runs on a regular schedule making it relatively easy to see the latest comparisons.
