### PR TITLE
Extend dmodex test timeout to 240 seconds

### DIFF
--- a/prrte/dmodex/dmodex.c
+++ b/prrte/dmodex/dmodex.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
     pmix_rank_t *locals = NULL;
     uint8_t j;
     pmix_info_t timeout;
-    int tlimit = 10;
+    int tlimit = 240;
 
     EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
 


### PR DESCRIPTION
Make the dmodex timeout be longer to handle large ppn cases.